### PR TITLE
Fix streams stuck in live state on relay failure (#38) + FFmpeg 8.0 build

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,53 @@
+name: Build Docker Images (PR)
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-zap-stream-core:
+    name: Build zap-stream-core
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build zap-stream-core
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./crates/zap-stream/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=zap-stream-core
+          cache-to: type=gha,mode=max,scope=zap-stream-core
+
+  build-n94-bridge:
+    name: Build n94-bridge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build n94-bridge
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./crates/n94-bridge/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=n94-bridge
+          cache-to: type=gha,mode=max,scope=n94-bridge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,26 +436,6 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -469,7 +449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.111",
 ]
@@ -791,7 +771,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76fc5953dd0f119db6f40ab5ab03059e88bdb4b6ec9d23d3bf4fb46ecafca991"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cfg-if",
  "cmake",
  "libc",
@@ -1527,27 +1507,24 @@ dependencies = [
 [[package]]
 name = "ffmpeg-rs-raw"
 version = "0.3.0"
-source = "git+https://git.v0l.io/Kieran/ffmpeg-rs-raw.git?rev=c5f3424b74005c75f6f3950f4e59dc05df23718e#c5f3424b74005c75f6f3950f4e59dc05df23718e"
+source = "git+https://git.v0l.io/Kieran/ffmpeg-rs-raw.git?rev=f6dc45ecea44b235476c4f2114f15ce935ab7201#f6dc45ecea44b235476c4f2114f15ce935ab7201"
 dependencies = [
  "anyhow",
  "ffmpeg-sys-the-third",
  "libc",
  "log 0.4.28",
- "slimbox",
 ]
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "3.0.1+ffmpeg-7.1"
-source = "git+https://github.com/v0l/ffmpeg-the-third.git?rev=bf1d21071e92ad7d212f9129eaf13faabeb42920#bf1d21071e92ad7d212f9129eaf13faabeb42920"
+version = "4.0.0+ffmpeg-8.0"
+source = "git+https://github.com/v0l/ffmpeg-the-third.git?rev=f6209599c7daff25eb8fcd0c335e9f5c9ec52244#f6209599c7daff25eb8fcd0c335e9f5c9ec52244"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "clang",
- "glob",
  "libc",
  "pkg-config",
- "regex",
  "vcpkg",
 ]
 
@@ -2636,12 +2613,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -3859,7 +3830,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.17",
@@ -3881,7 +3852,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4433,12 +4404,6 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4986,11 +4951,6 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "slimbox"
-version = "0.1.0"
-source = "git+https://github.com/v0l/slimbox?rev=f40fb964fc515b40807d925104ee7a5f3122c1fc#f40fb964fc515b40807d925104ee7a5f3122c1fc"
 
 [[package]]
 name = "slotmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,8 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-rs-raw"
-version = "0.3.0"
-source = "git+https://git.v0l.io/Kieran/ffmpeg-rs-raw.git?rev=f6dc45ecea44b235476c4f2114f15ce935ab7201#f6dc45ecea44b235476c4f2114f15ce935ab7201"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46e4544c444801cde2cbfb9f0d77f6bb19335ff7471f99fb71696bb3715be30"
 dependencies = [
  "anyhow",
  "ffmpeg-sys-the-third",
@@ -1517,8 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "4.0.0+ffmpeg-8.0"
-source = "git+https://github.com/v0l/ffmpeg-the-third.git?rev=f6209599c7daff25eb8fcd0c335e9f5c9ec52244#f6209599c7daff25eb8fcd0c335e9f5c9ec52244"
+version = "5.0.0+ffmpeg-8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00c204bb97c2b6c0329104c3e8bcf58d4d13cc88a04233326570672e0c2c5c9"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codegen-units = 1
 panic = "unwind"
 
 [workspace.dependencies]
-ffmpeg-rs-raw = { git = "https://git.v0l.io/Kieran/ffmpeg-rs-raw.git", rev = "f6dc45ecea44b235476c4f2114f15ce935ab7201" }
+ffmpeg-rs-raw = "1.0.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = "0.7"
 anyhow = { version = "1", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codegen-units = 1
 panic = "unwind"
 
 [workspace.dependencies]
-ffmpeg-rs-raw = { git = "https://git.v0l.io/Kieran/ffmpeg-rs-raw.git", rev = "c5f3424b74005c75f6f3950f4e59dc05df23718e" }
+ffmpeg-rs-raw = { git = "https://git.v0l.io/Kieran/ffmpeg-rs-raw.git", rev = "f6dc45ecea44b235476c4f2114f15ce935ab7201" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = "0.7"
 anyhow = { version = "1", features = ["backtrace"] }

--- a/crates/core/src/endpoint.rs
+++ b/crates/core/src/endpoint.rs
@@ -783,8 +783,8 @@ mod tests {
     use super::*;
     use crate::mux::SegmentType;
     use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVCodecID;
-    use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_YUV420P;
-    use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat::AV_SAMPLE_FMT_FLTP;
+    use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat;
+    use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat;
     use tracing_subscriber::filter::LevelFilter;
 
     #[test]
@@ -800,8 +800,8 @@ mod tests {
                 IngressStream {
                     index: 0,
                     stream_type: StreamType::Video,
-                    codec: AVCodecID::AV_CODEC_ID_H264 as _,
-                    format: AV_PIX_FMT_YUV420P as _,
+                    codec: AVCodecID::H264.0 as _,
+                    format: AVPixelFormat::YUV420P.0 as _,
                     width: 1920,
                     height: 1080,
                     bitrate: 8_000_000,
@@ -811,8 +811,8 @@ mod tests {
                 IngressStream {
                     index: 1,
                     stream_type: StreamType::Video,
-                    codec: AVCodecID::AV_CODEC_ID_H264 as _,
-                    format: AV_PIX_FMT_YUV420P as _,
+                    codec: AVCodecID::H264.0 as _,
+                    format: AVPixelFormat::YUV420P.0 as _,
                     width: 1280,
                     height: 720,
                     bitrate: 6_000_000,
@@ -822,8 +822,8 @@ mod tests {
                 IngressStream {
                     index: 2,
                     stream_type: StreamType::Audio,
-                    codec: AVCodecID::AV_CODEC_ID_AAC as _,
-                    format: AV_SAMPLE_FMT_FLTP as _,
+                    codec: AVCodecID::AAC.0 as _,
+                    format: AVSampleFormat::FLTP.0 as _,
                     bitrate: 320_000,
                     sample_rate: 44_100,
                     channels: 2,

--- a/crates/core/src/generator.rs
+++ b/crates/core/src/generator.rs
@@ -1,12 +1,9 @@
 use crate::ingress::IngressStream;
 use anyhow::{Result, bail};
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVColorSpace::AVCOL_SPC_RGB;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPictureType::AV_PICTURE_TYPE_NONE;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_RGBA;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat::AV_SAMPLE_FMT_FLTP;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_FRAME_FLAG_KEY, AVPixelFormat, AVRational, AVStream, av_channel_layout_default,
-    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_q2d, av_rescale_q,
+    AV_FRAME_FLAG_KEY, AVColorSpace, AVPictureType, AVPixelFormat, AVRational, AVSampleFormat,
+    AVStream, av_channel_layout_default, av_frame_alloc, av_frame_free, av_frame_get_buffer,
+    av_q2d, av_rescale_q,
 };
 use ffmpeg_rs_raw::{AvFrameRef, Scaler};
 use fontdue::Font;
@@ -193,13 +190,13 @@ impl FrameGenerator {
 
                 (*src_frame).width = self.width as _;
                 (*src_frame).height = self.height as _;
-                (*src_frame).pict_type = AV_PICTURE_TYPE_NONE;
+                (*src_frame).pict_type = AVPictureType::NONE;
                 // FFmpeg 8.0 removed AVFrame.key_frame; use the AV_FRAME_FLAG_KEY flag instead
                 // (available since FFmpeg 6.1, so this is portable across 7.x and 8.x).
                 (*src_frame).flags |= AV_FRAME_FLAG_KEY;
-                (*src_frame).colorspace = AVCOL_SPC_RGB;
+                (*src_frame).colorspace = AVColorSpace::RGB;
                 //internally always use RGBA, we convert frame to target pixel format at the end
-                (*src_frame).format = AV_PIX_FMT_RGBA as _;
+                (*src_frame).format = AVPixelFormat::RGBA.0 as _;
                 (*src_frame).pts = self.video_pts;
                 (*src_frame).duration = self.pts_per_frame() as _;
                 (*src_frame).time_base = self.video_timebase;
@@ -390,7 +387,7 @@ impl FrameGenerator {
             // Generate audio if we don't have enough to cover the next video frame
             if self.audio_pts < audio_pts_needed {
                 let audio_frame = av_frame_alloc();
-                (*audio_frame).format = AV_SAMPLE_FMT_FLTP as _;
+                (*audio_frame).format = AVSampleFormat::FLTP.0 as _;
                 (*audio_frame).nb_samples = self.audio_frame_size as _;
                 (*audio_frame).duration = self.audio_frame_size as _;
                 (*audio_frame).sample_rate = self.audio_sample_rate as _;
@@ -485,7 +482,6 @@ impl FrameGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_YUV420P;
 
     #[test]
     fn test_frame_timing_synchronization() {
@@ -499,7 +495,7 @@ mod tests {
                 fps,
                 1280,
                 720,
-                AV_PIX_FMT_YUV420P,
+                AVPixelFormat::YUV420P,
                 sample_rate,
                 frame_size,
                 channels,
@@ -603,7 +599,7 @@ mod tests {
                 fps,
                 1280,
                 720,
-                AV_PIX_FMT_YUV420P,
+                AVPixelFormat::YUV420P,
                 sample_rate,
                 1024,
                 2,

--- a/crates/core/src/generator.rs
+++ b/crates/core/src/generator.rs
@@ -5,8 +5,8 @@ use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPictureType::AV_PICTURE_TYPE_NONE;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_RGBA;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat::AV_SAMPLE_FMT_FLTP;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AVPixelFormat, AVRational, AVStream, av_channel_layout_default, av_frame_alloc, av_frame_free,
-    av_frame_get_buffer, av_q2d, av_rescale_q,
+    AV_FRAME_FLAG_KEY, AVPixelFormat, AVRational, AVStream, av_channel_layout_default,
+    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_q2d, av_rescale_q,
 };
 use ffmpeg_rs_raw::{AvFrameRef, Scaler};
 use fontdue::Font;
@@ -194,7 +194,9 @@ impl FrameGenerator {
                 (*src_frame).width = self.width as _;
                 (*src_frame).height = self.height as _;
                 (*src_frame).pict_type = AV_PICTURE_TYPE_NONE;
-                (*src_frame).key_frame = 1;
+                // FFmpeg 8.0 removed AVFrame.key_frame; use the AV_FRAME_FLAG_KEY flag instead
+                // (available since FFmpeg 6.1, so this is portable across 7.x and 8.x).
+                (*src_frame).flags |= AV_FRAME_FLAG_KEY;
                 (*src_frame).colorspace = AVCOL_SPC_RGB;
                 //internally always use RGBA, we convert frame to target pixel format at the end
                 (*src_frame).format = AV_PIX_FMT_RGBA as _;

--- a/crates/core/src/ingress/test.rs
+++ b/crates/core/src/ingress/test.rs
@@ -5,8 +5,8 @@ use crate::metrics::EndpointStats;
 use crate::overseer::Overseer;
 use anyhow::Result;
 use chrono::Utc;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_YUV420P;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat::AV_SAMPLE_FMT_FLTP;
+use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat;
+use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{AV_PROFILE_H264_MAIN, AVRational};
 use ffmpeg_rs_raw::{Encoder, Muxer};
 use ringbuf::traits::{Observer, Split};
@@ -97,7 +97,7 @@ impl TestPatternSrc {
                 .with_stream_index(0)
                 .with_framerate(VIDEO_FPS)?
                 .with_bitrate(1_000_000)
-                .with_pix_fmt(AV_PIX_FMT_YUV420P)
+                .with_pix_fmt(AVPixelFormat::YUV420P)
                 .with_width(VIDEO_WIDTH as _)
                 .with_height(VIDEO_HEIGHT as _)
                 .with_level(51)
@@ -110,7 +110,7 @@ impl TestPatternSrc {
                 .with_stream_index(1)
                 .with_default_channel_layout(1)
                 .with_bitrate(128_000)
-                .with_sample_format(AV_SAMPLE_FMT_FLTP)
+                .with_sample_format(AVSampleFormat::FLTP)
                 .with_sample_rate(SAMPLE_RATE as _)?
                 .open(None)?
         };
@@ -144,7 +144,7 @@ impl TestPatternSrc {
                 VIDEO_FPS,
                 VIDEO_WIDTH,
                 VIDEO_HEIGHT,
-                AV_PIX_FMT_YUV420P,
+                AVPixelFormat::YUV420P,
                 SAMPLE_RATE,
                 frame_size,
                 1,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -50,14 +50,14 @@ pub use hang;
 #[cfg(feature = "ffmpeg")]
 pub fn map_codec_id(codec: &str) -> Option<AVCodecID> {
     match codec {
-        "h264" => Some(AVCodecID::AV_CODEC_ID_H264),
-        "h265" | "hevc" => Some(AVCodecID::AV_CODEC_ID_HEVC),
-        "av1" => Some(AVCodecID::AV_CODEC_ID_AV1),
-        "vp9" => Some(AVCodecID::AV_CODEC_ID_VP9),
-        "vp8" => Some(AVCodecID::AV_CODEC_ID_VP8),
-        "aac" => Some(AVCodecID::AV_CODEC_ID_AAC),
-        "opus" => Some(AVCodecID::AV_CODEC_ID_OPUS),
-        "webp" => Some(AVCodecID::AV_CODEC_ID_WEBP),
+        "h264" => Some(AVCodecID::H264),
+        "h265" | "hevc" => Some(AVCodecID::HEVC),
+        "av1" => Some(AVCodecID::AV1),
+        "vp9" => Some(AVCodecID::VP9),
+        "vp8" => Some(AVCodecID::VP8),
+        "aac" => Some(AVCodecID::AAC),
+        "opus" => Some(AVCodecID::OPUS),
+        "webp" => Some(AVCodecID::WEBP),
         _ => None,
     }
 }

--- a/crates/core/src/mux/hls/variant.rs
+++ b/crates/core/src/mux/hls/variant.rs
@@ -5,12 +5,10 @@ use crate::mux::{HlsVariantStream, SegmentType};
 use crate::variant::VariantStream;
 use anyhow::{Result, bail, ensure};
 use chrono::Utc;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVCodecID::AV_CODEC_ID_H264;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVMediaType::AVMEDIA_TYPE_VIDEO;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_NOPTS_VALUE, AV_PKT_FLAG_KEY, AVIO_FLAG_WRITE, av_freep, av_get_bits_per_pixel,
-    av_interleaved_write_frame, av_pix_fmt_desc_get, av_q2d, av_write_frame, avio_closep,
-    avio_flush, avio_open, avio_size,
+    AV_NOPTS_VALUE, AV_PKT_FLAG_KEY, AVIO_FLAG_WRITE, AVCodecID, AVMediaType, av_freep,
+    av_get_bits_per_pixel, av_interleaved_write_frame, av_pix_fmt_desc_get, av_q2d, av_write_frame,
+    avio_closep, avio_flush, avio_open, avio_size,
 };
 use ffmpeg_rs_raw::{AvPacketRef, Muxer, bail_ffmpeg, cstr};
 use m3u8_rs::Playlist::MediaPlaylist;
@@ -359,7 +357,7 @@ impl HlsVariant {
         let mut result = EgressResult::None;
         let stream_type = unsafe { (*(*pkt_stream).codecpar).codec_type };
         let mut can_split =
-            stream_type == AVMEDIA_TYPE_VIDEO && (pkt.flags & AV_PKT_FLAG_KEY == AV_PKT_FLAG_KEY);
+            stream_type == AVMediaType::VIDEO && (pkt.flags & AV_PKT_FLAG_KEY == AV_PKT_FLAG_KEY);
         let mut is_ref_pkt = stream_index == self.ref_stream_index;
 
         if pkt.pts == AV_NOPTS_VALUE {
@@ -384,7 +382,7 @@ impl HlsVariant {
 
             let should_end_this_segment = cur_duration >= self.segment_length() as f64;
             let split_seg = can_split && should_end_this_segment;
-            let split_partial = stream_type == AVMEDIA_TYPE_VIDEO
+            let split_partial = stream_type == AVMediaType::VIDEO
                 && self.low_latency
                 && (cur_part_duration >= self.partial_target_duration as f64 || split_seg);
 
@@ -748,7 +746,7 @@ impl HlsVariant {
 
                 match stream {
                     HlsVariantStream::Video { .. } => {
-                        if (*p).codec_id == AV_CODEC_ID_H264 {
+                        if (*p).codec_id == AVCodecID::H264 {
                             // Use profile and level from codec parameters
                             let profile_idc = (*p).profile as u8;
                             let level_idc = (*p).level as u8;

--- a/crates/core/src/pipeline/worker.rs
+++ b/crates/core/src/pipeline/worker.rs
@@ -3,10 +3,9 @@ use crate::overseer::Overseer;
 use crate::pipeline::PipelinePlugin;
 use crate::variant::VariantStream;
 use anyhow::{Result, anyhow, bail};
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVCodecID::AV_CODEC_ID_WEBP;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPictureType::AV_PICTURE_TYPE_NONE;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_YUV420P;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::{AV_NOPTS_VALUE, av_get_pix_fmt_name, av_rescale_q};
+use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
+    AV_NOPTS_VALUE, AVCodecID, AVPictureType, AVPixelFormat, av_get_pix_fmt_name, av_rescale_q,
+};
 use ffmpeg_rs_raw::{AudioFifo, AvFrameRef, AvPacketRef, Encoder, Resample, Scaler, rstr};
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
@@ -61,21 +60,21 @@ impl PipelineWorkerThread {
         let thumb_start = Instant::now();
 
         let encoder = unsafe {
-            Encoder::new(AV_CODEC_ID_WEBP)?
+            Encoder::new(AVCodecID::WEBP)?
                 .with_height(frame.height)
                 .with_width(frame.width)
-                .with_pix_fmt(AV_PIX_FMT_YUV420P)
+                .with_pix_fmt(AVPixelFormat::YUV420P)
                 .open(None)?
         };
 
         // use scaler to convert pixel format if not YUV420P
-        if frame.format != AV_PIX_FMT_YUV420P as i32 {
+        if frame.format != AVPixelFormat::YUV420P.0 as i32 {
             let mut sw = Scaler::new();
             let new_frame = sw.process_frame(
                 &frame,
                 frame.width as _,
                 frame.height as _,
-                AV_PIX_FMT_YUV420P,
+                AVPixelFormat::YUV420P,
             )?;
             encoder.save_picture(&new_frame, dst_pic.to_str().unwrap())?;
         } else {
@@ -182,7 +181,7 @@ impl PipelineWorkerThread {
             let enc_ctx = e.codec_context();
 
             if frame.width != 0
-                && frame.format != unsafe { (*enc_ctx).pix_fmt } as i32
+                && frame.format != unsafe { (*enc_ctx).pix_fmt }.0
                 && self.scaler.is_none()
             {
                 warn!(
@@ -196,7 +195,7 @@ impl PipelineWorkerThread {
                 self.scaler.replace(sc);
                 return self.scale_encode_frame(frame.clone());
             }
-            frame.pict_type = AV_PICTURE_TYPE_NONE;
+            frame.pict_type = AVPictureType::NONE;
             frame.pts = unsafe { av_rescale_q(frame.pts, frame.time_base, (*enc_ctx).time_base) };
             frame.pkt_dts = AV_NOPTS_VALUE;
             frame.duration =

--- a/crates/core/src/test_hls_timing.rs
+++ b/crates/core/src/test_hls_timing.rs
@@ -5,9 +5,8 @@ use crate::mux::{HlsMuxer, SegmentType};
 use crate::variant::{AudioVariant, VariantStream, VideoVariant};
 use anyhow::{Context, Result};
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_CODEC_FLAG_GLOBAL_HEADER, AV_NOPTS_VALUE, AV_PROFILE_H264_MAIN,
-    AVMediaType::AVMEDIA_TYPE_AUDIO, AVMediaType::AVMEDIA_TYPE_VIDEO,
-    AVPixelFormat::AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat::AV_SAMPLE_FMT_FLTP, av_q2d,
+    AV_CODEC_FLAG_GLOBAL_HEADER, AV_NOPTS_VALUE, AV_PROFILE_H264_MAIN, AVMediaType, AVPixelFormat,
+    AVRational, AVSampleFormat, av_q2d,
 };
 use ffmpeg_rs_raw::{Demuxer, Encoder};
 use m3u8_rs::{MediaSegmentType, parse_media_playlist};
@@ -168,7 +167,7 @@ impl HlsTimingTester {
                 .with_stream_index(0)
                 .with_framerate(VIDEO_FPS)?
                 .with_bitrate(1_000_000)
-                .with_pix_fmt(AV_PIX_FMT_YUV420P)
+                .with_pix_fmt(AVPixelFormat::YUV420P)
                 .with_width(VIDEO_WIDTH as _)
                 .with_height(VIDEO_HEIGHT as _)
                 .with_level(51)
@@ -192,7 +191,7 @@ impl HlsTimingTester {
                 .with_stream_index(1)
                 .with_default_channel_layout(1)
                 .with_bitrate(128_000)
-                .with_sample_format(AV_SAMPLE_FMT_FLTP)
+                .with_sample_format(AVSampleFormat::FLTP)
                 .with_sample_rate(SAMPLE_RATE as _)?;
 
             if need_global_header {
@@ -259,7 +258,7 @@ impl HlsTimingTester {
             VIDEO_FPS,
             VIDEO_WIDTH,
             VIDEO_HEIGHT,
-            AV_PIX_FMT_YUV420P,
+            AVPixelFormat::YUV420P,
             SAMPLE_RATE,
             frame_size,
             1,
@@ -649,7 +648,7 @@ impl HlsTimingTester {
                         let current_stream_idx = (*stream).index as usize;
 
                         match codec_type {
-                            AVMEDIA_TYPE_VIDEO => {
+                            AVMediaType::VIDEO => {
                                 if video_stream_idx.is_none() {
                                     video_stream_idx = Some(current_stream_idx);
                                 }
@@ -661,7 +660,7 @@ impl HlsTimingTester {
                                     video_last_duration = duration;
                                 }
                             }
-                            AVMEDIA_TYPE_AUDIO => {
+                            AVMediaType::AUDIO => {
                                 if audio_stream_idx.is_none() {
                                     audio_stream_idx = Some(current_stream_idx);
                                 }

--- a/crates/core/src/variant/audio.rs
+++ b/crates/core/src/variant/audio.rs
@@ -3,9 +3,9 @@ use crate::ingress::IngressStream;
 use crate::map_codec_id;
 use anyhow::Result;
 use anyhow::bail;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVSampleFormat::AV_SAMPLE_FMT_NONE;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_CODEC_FLAG_GLOBAL_HEADER, AV_CODEC_FLAG_LOW_DELAY, av_get_sample_fmt, avcodec_find_encoder,
+    AV_CODEC_FLAG_GLOBAL_HEADER, AV_CODEC_FLAG_LOW_DELAY, AVSampleFormat, av_get_sample_fmt,
+    avcodec_find_encoder,
 };
 use ffmpeg_rs_raw::{Encoder, cstr, free_cstr};
 use serde::{Deserialize, Serialize};
@@ -78,10 +78,10 @@ impl AudioVariant {
             let n_c = cstr!(self.sample_format.as_str());
             let id = av_get_sample_fmt(n_c);
             free_cstr!(n_c);
-            if id == AV_SAMPLE_FMT_NONE {
+            if id == AVSampleFormat::NONE {
                 bail!("Sample format {} not supported", self.sample_format);
             }
-            Ok(id as _)
+            Ok(id.0 as _)
         }
     }
 

--- a/crates/core/src/variant/video.rs
+++ b/crates/core/src/variant/video.rs
@@ -2,11 +2,9 @@ use crate::egress::EncoderParam;
 use crate::ingress::IngressStream;
 use crate::map_codec_id;
 use anyhow::{Result, bail};
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVColorSpace::AVCOL_SPC_BT709;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVPixelFormat::AV_PIX_FMT_NONE;
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_CODEC_FLAG_GLOBAL_HEADER, AV_CODEC_FLAG_LOW_DELAY, AVColorRange, AVRational,
-    av_color_range_from_name, av_color_space_from_name, av_get_pix_fmt, av_q2d,
+    AV_CODEC_FLAG_GLOBAL_HEADER, AV_CODEC_FLAG_LOW_DELAY, AVColorRange, AVColorSpace, AVPixelFormat,
+    AVRational, av_color_range_from_name, av_color_space_from_name, av_get_pix_fmt, av_q2d,
     avcodec_find_encoder,
 };
 use ffmpeg_rs_raw::{Encoder, cstr, free_cstr, get_ffmpeg_error_msg, rstr};
@@ -147,10 +145,10 @@ impl VideoVariant {
             let c_fmt = cstr!(self.pixel_format.as_str());
             let fmt = av_get_pix_fmt(c_fmt);
             free_cstr!(c_fmt);
-            if fmt == AV_PIX_FMT_NONE {
+            if fmt == AVPixelFormat::NONE {
                 bail!("Invalid pixel format {}", self.pixel_format);
             }
-            Ok(fmt as _)
+            Ok(fmt.0 as _)
         }
     }
 
@@ -205,7 +203,7 @@ impl VideoVariant {
                             (*ctx).colorspace = transmute(cs);
                         }
                     } else {
-                        (*ctx).colorspace = AVCOL_SPC_BT709;
+                        (*ctx).colorspace = AVColorSpace::BT709;
                     }
 
                     if !self.color_range.is_empty() {
@@ -222,7 +220,7 @@ impl VideoVariant {
                             (*ctx).color_range = transmute(cr);
                         }
                     } else {
-                        (*ctx).color_range = AVColorRange::AVCOL_RANGE_MPEG;
+                        (*ctx).color_range = AVColorRange::MPEG;
                     }
 
                     // Set GLOBAL_HEADER flag for fMP4 HLS and recorder contexts

--- a/crates/zap-stream/src/bin/hls_debug.rs
+++ b/crates/zap-stream/src/bin/hls_debug.rs
@@ -1,8 +1,6 @@
 use anyhow::{Context, Result};
 use ffmpeg_rs_raw::Demuxer;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    AV_NOPTS_VALUE, AVMediaType::AVMEDIA_TYPE_AUDIO, AVMediaType::AVMEDIA_TYPE_VIDEO, av_q2d,
-};
+use ffmpeg_rs_raw::ffmpeg_sys_the_third::{AV_NOPTS_VALUE, AVMediaType, av_q2d};
 use m3u8_rs::{MediaSegmentType, parse_media_playlist};
 use std::env;
 use std::fmt;
@@ -646,7 +644,7 @@ fn analyze_segment_with_reader(reader: Box<dyn Read>) -> Result<SegmentDurations
                     let current_stream_idx = (*stream).index as usize;
 
                     match codec_type {
-                        AVMEDIA_TYPE_VIDEO => {
+                        AVMediaType::VIDEO => {
                             if video_stream_idx.is_none() {
                                 video_stream_idx = Some(current_stream_idx);
                             }
@@ -659,7 +657,7 @@ fn analyze_segment_with_reader(reader: Box<dyn Read>) -> Result<SegmentDurations
                                 video_packets += 1;
                             }
                         }
-                        AVMEDIA_TYPE_AUDIO => {
+                        AVMediaType::AUDIO => {
                             if audio_stream_idx.is_none() {
                                 audio_stream_idx = Some(current_stream_idx);
                             }
@@ -765,7 +763,7 @@ fn analyze_partial_segment(
 }
 
 fn analyze_init_segment(path: &Path) -> Result<InitSegmentInfo> {
-    use ffmpeg_rs_raw::ffmpeg_sys_the_third::{AVPixelFormat::AV_PIX_FMT_NONE, avcodec_get_name};
+    use ffmpeg_rs_raw::ffmpeg_sys_the_third::{AVPixelFormat, avcodec_get_name};
     use std::ffi::CStr;
 
     let mut demuxer = Demuxer::new(path.to_str().unwrap())?;
@@ -797,7 +795,7 @@ fn analyze_init_segment(path: &Path) -> Result<InitSegmentInfo> {
                 };
 
                 let (codec_type_str, width, height, pixel_format) = match codec_type {
-                    AVMEDIA_TYPE_VIDEO => {
+                    AVMediaType::VIDEO => {
                         let w = if (*codecpar).width > 0 {
                             Some((*codecpar).width)
                         } else {
@@ -809,7 +807,7 @@ fn analyze_init_segment(path: &Path) -> Result<InitSegmentInfo> {
                             None
                         };
 
-                        let pix_fmt = if (*codecpar).format != AV_PIX_FMT_NONE as i32 {
+                        let pix_fmt = if (*codecpar).format != AVPixelFormat::NONE.0 as i32 {
                             pixel_format_set = true;
                             // Skip pixel format name resolution for now due to type mismatch
                             Some("yuv420p".to_string()) // Common default
@@ -819,7 +817,7 @@ fn analyze_init_segment(path: &Path) -> Result<InitSegmentInfo> {
 
                         ("video".to_string(), w, h, pix_fmt)
                     }
-                    AVMEDIA_TYPE_AUDIO => ("audio".to_string(), None, None, None),
+                    AVMediaType::AUDIO => ("audio".to_string(), None, None, None),
                     _ => ("other".to_string(), None, None, None),
                 };
 

--- a/crates/zap-stream/src/main.rs
+++ b/crates/zap-stream/src/main.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use axum::Router;
 use clap::Parser;
 use config::Config;
-use ffmpeg_rs_raw::ffmpeg_sys_the_third::AVCodecID::{AV_CODEC_ID_H264, AV_CODEC_ID_HEVC};
 use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
-    av_hwdevice_get_type_name, av_log_set_callback, av_version_info, avcodec_find_decoder,
+    AVCodecID, av_hwdevice_get_type_name, av_log_set_callback, av_version_info,
+    avcodec_find_decoder,
 };
 use ffmpeg_rs_raw::{Decoder, ffmpeg_sys_the_third, rstr};
 use payments_rs::lightning::setup_crypto_provider;
@@ -109,13 +109,13 @@ async fn main() -> Result<()> {
 
         let mut has_hw_accel = false;
         let decoder = Decoder::new();
-        let h264_codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+        let h264_codec = avcodec_find_decoder(AVCodecID::H264);
         for hw in decoder.list_supported_hw_accel(h264_codec) {
             let device = av_hwdevice_get_type_name(hw);
             info!("Supported HW accel=h264_{}", rstr!(device));
             has_hw_accel = true;
         }
-        let h265_codec = avcodec_find_decoder(AV_CODEC_ID_HEVC);
+        let h265_codec = avcodec_find_decoder(AVCodecID::HEVC);
         for hw in decoder.list_supported_hw_accel(h265_codec) {
             let device = av_hwdevice_get_type_name(hw);
             info!("Supported HW accel=h265_{}", rstr!(device));

--- a/crates/zap-stream/src/multitrack.rs
+++ b/crates/zap-stream/src/multitrack.rs
@@ -96,10 +96,10 @@ impl MultiTrackEngine {
                 IngressStream {
                     index: 0,
                     stream_type: StreamType::Video,
-                    codec: ingest_video_codec_id as _,
+                    codec: ingest_video_codec_id.0 as _,
                     format: unsafe {
                         let str = cstr!(pix_fmt);
-                        let ret: i32 = av_get_pix_fmt(str) as _;
+                        let ret: i32 = av_get_pix_fmt(str).0 as _;
                         if ret == -1 {
                             return Ok(MultiTrackConfigResponse::status_error(format!(
                                 "Could not find pixel format {}",
@@ -139,10 +139,10 @@ impl MultiTrackEngine {
                 IngressStream {
                     index: 1,
                     stream_type: StreamType::Audio,
-                    codec: ingest_audio_codec_id as _,
+                    codec: ingest_audio_codec_id.0 as _,
                     format: unsafe {
                         let str = cstr!(sample_fmt);
-                        let ret: i32 = av_get_sample_fmt(str) as _;
+                        let ret: i32 = av_get_sample_fmt(str).0 as _;
                         free_cstr!(str);
                         if ret == -1 {
                             return Ok(MultiTrackConfigResponse::status_error(format!(

--- a/crates/zap-stream/src/nostr.rs
+++ b/crates/zap-stream/src/nostr.rs
@@ -2,6 +2,7 @@ use crate::stream_manager::StreamManager;
 use anyhow::{bail, Result};
 use nostr_sdk::{Client, Event, EventBuilder, JsonUtil, Kind, Tag, Timestamp};
 use std::ops::Add;
+use tracing::warn;
 use zap_stream_db::{UserStream, UserStreamState};
 
 #[derive(Clone)]
@@ -19,9 +20,25 @@ impl N53Publisher {
     }
 
     pub async fn publish(&self, ev: &Event) -> Result<()> {
+        // `send_event` only errors on a hard transport failure; it returns Ok even when every
+        // relay rejected the event. Treat "no relay accepted it" as a failure so callers can
+        // tell that the update did not actually land anywhere.
         let output = self.client.send_event(ev).await?;
         if output.success.is_empty() {
-            bail!("Failed to publish event: no relay accepted it");
+            bail!(
+                "Failed to publish event {}: no relay accepted it ({} rejected)",
+                ev.id,
+                output.failed.len()
+            );
+        }
+        if !output.failed.is_empty() {
+            warn!(
+                "Event {} accepted by {} relay(s), rejected by {}: {:?}",
+                ev.id,
+                output.success.len(),
+                output.failed.len(),
+                output.failed
+            );
         }
         Ok(())
     }

--- a/crates/zap-stream/src/overseer.rs
+++ b/crates/zap-stream/src/overseer.rs
@@ -215,7 +215,12 @@ impl ZapStreamOverseer {
         self.moq_bind = bind;
     }
 
-    pub async fn publish_stream_event(
+    /// Build the nostr event for a stream without publishing it.
+    ///
+    /// This is the local, reliable half of [`Self::publish_stream_event`]: it never touches
+    /// the relays, so it can be used to persist the event (e.g. in its ended state) to the DB
+    /// independently of whether the subsequent relay publish succeeds.
+    pub async fn build_stream_event(
         &self,
         stream: &UserStream,
         pubkey: &Vec<u8>,
@@ -269,7 +274,16 @@ impl ZapStreamOverseer {
             None
         };
         let ev = self.n53.stream_to_event(stream, extra_tags, alt).await?;
-        self.client.send_event(&ev).await?;
+        Ok(ev)
+    }
+
+    pub async fn publish_stream_event(
+        &self,
+        stream: &UserStream,
+        pubkey: &Vec<u8>,
+    ) -> Result<Event> {
+        let ev = self.build_stream_event(stream, pubkey).await?;
+        self.n53.publish(&ev).await?;
         info!("Published stream event {}", ev.id.to_hex());
         self.last_event_publish
             .store(Timestamp::now().as_secs(), Ordering::Relaxed);
@@ -895,9 +909,24 @@ impl Overseer for ZapStreamOverseer {
 
         stream.state = UserStreamState::Ended;
         stream.ends = Some(Utc::now());
-        let event = self.publish_stream_event(&stream, &user.pubkey).await?;
+
+        // Build the ended-state event and persist it to the DB BEFORE publishing to relays.
+        // Building is local and reliable; publishing is not (e.g. "connection closed before
+        // message completed"). If the publish fails we must still record the ended state and
+        // the ended event locally, otherwise the stream stays stuck live: it keeps counting
+        // as live, blocks the user from starting a new stream and prevents recording cleanup.
+        let event = self.build_stream_event(&stream, &user.pubkey).await?;
         stream.event = Some(event.as_json());
         self.db.update_stream(&stream).await?;
+
+        // Best-effort publish of the end event; a failure here must not abort on_end.
+        if let Err(e) = self.n53.publish(&event).await {
+            error!("Failed to publish stream end event for {}: {}", stream.id, e);
+        } else {
+            info!("Published stream event {}", event.id.to_hex());
+            self.last_event_publish
+                .store(Timestamp::now().as_secs(), Ordering::Relaxed);
+        }
 
         info!("Stream ended {}", stream.id);
         Ok(())

--- a/crates/zap-stream/src/plugin/track_id.rs
+++ b/crates/zap-stream/src/plugin/track_id.rs
@@ -60,7 +60,7 @@ impl TrackIdPlugin {
             ctx,
             sample_time,
             resample: Mutex::new(Resample::new(
-                AVSampleFormat::AV_SAMPLE_FMT_S16,
+                AVSampleFormat::S16,
                 sample_rate,
                 channels as _,
             )),


### PR DESCRIPTION
## Summary

Three related changes (the FFmpeg work unblocks the Docker build that #38 needs to ship in):

### 1. Streams stuck in "live" state when relay publish fails (closes #38)

`ZapStreamOverseer::on_end()` marked a stream `Ended` in the DB only **after** successfully publishing the kind-30311 nostr event. When the relay publish failed — e.g. the `connection closed before message completed` error from the issue — the `?` aborted the function and the DB was never updated, leaving the stream pinned `Live` forever. Consequences:

- it keeps being returned by `list_live_streams_by_node` and "checked alive" every poll cycle,
- `live_primary_count` stays non-zero, so the user **can't start a new stream** ("Primary key is already in use"),
- recording/HLS cleanup (gated on the `Ended` state) never runs.

**Fix:**
- Split `publish_stream_event` into `build_stream_event` (local, reliable) + the publish step.
- `on_end` now builds the **ended-state** event, persists it to the DB (`state = Ended` + event JSON) **first**, then publishes **best-effort** — a failure is logged, not propagated. The ended event is still stored in the DB as before.
- Route stream-event publishing through `N53Publisher::publish` instead of `Client::send_event` directly, so the existing "no relay accepted it" guard applies (`send_event` returns `Ok` even when every relay rejects). `publish()` also now `warn!`s on partial failures with relay counts/reasons.

### 2 + 3. FFmpeg 8 / ffmpeg-rs-raw 1.0.0 migration

The working tree had bumped the ffmpeg dependency to FFmpeg 8. FFmpeg 8 removed `AVFrame.key_frame` (replaced with the `AV_FRAME_FLAG_KEY` flag), which broke the Docker build (its base image ships 8.x headers).

This PR moves from the git-pinned fork to the **published `ffmpeg-rs-raw 1.0.0`** (crates.io), which pulls `ffmpeg-sys-the-third 5.0.0+ffmpeg-8.1` and drops the git dependencies. `ffmpeg-sys-the-third 5.0.0` generates C enums as **NewType structs** with prefix-stripped associated constants instead of plain Rust enums, so all call sites were migrated:

- import the enum type rather than the bare variant;
- `AV_PIX_FMT_X` / `AV_CODEC_ID_X` / `AVCOL_SPC_X` / … → `AVPixelFormat::X` / `AVCodecID::X` / `AVColorSpace::X`;
- newtype values cast to int now use `.0` (e.g. `pix_fmt.0`, `id.0 as _`) instead of `as i32`;
- enum-typed struct fields (`pix_fmt`, `sample_fmt`, `colorspace`, `color_range`, `pict_type`, `codec_id`, `codec_type`) are the newtype, so they're assigned the constant directly.

## Testing

- `docker build -f ./crates/zap-stream/Dockerfile .` (FFmpeg 8.1) builds green; the image's `zap-stream --version` smoke test passes.
- `cargo build -p zap-stream-core -p zap-stream -p n94-bridge` is clean locally.
- Note: `crates/n94` (an unfinished experimental crate) fails `cargo build --workspace` due to pre-existing `Overseer`/`EndpointConfigurator` trait drift — identical on `main`, untouched here, and not built by either CI Docker image.

## Follow-up (not in this PR)

If the end event fails to reach any relay, the DB is correctly cleaned up but nostr clients may briefly still show the stream live until the event goes stale — `check_streams` only republishes streams still live in the DB. A republish-on-recently-ended pass in the poller would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)