### PR TITLE
feat(hls): CMAF audio stream grouping for fMP4 output

### DIFF
--- a/crates/core/src/egress/mod.rs
+++ b/crates/core/src/egress/mod.rs
@@ -44,6 +44,10 @@ pub struct EgressSegment {
     pub path: PathBuf,
     /// SHA-256 hash of the file
     pub sha256: [u8; 32],
+    /// Whether this segment belongs to an audio-only rendition (CMAF audio group).
+    /// Such renditions are shared across every video variant and are not billed
+    /// separately.
+    pub audio_only: bool,
 }
 
 pub enum EncoderOrSourceStream<'a> {

--- a/crates/core/src/mux/hls/mod.rs
+++ b/crates/core/src/mux/hls/mod.rs
@@ -1,6 +1,7 @@
-use crate::egress::{EgressResult, EncoderVariantGroup};
+use crate::egress::{EgressResult, EncoderVariant, EncoderVariantGroup};
 use crate::mux::SegmentType;
 use crate::mux::hls::variant::HlsVariant;
+use crate::variant::VariantStream;
 use anyhow::Result;
 use ffmpeg_rs_raw::AvPacketRef;
 use itertools::Itertools;
@@ -10,6 +11,14 @@ use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{trace, warn};
 use uuid::Uuid;
+
+/// Returns true if this encoder variant carries an audio stream
+fn is_audio_variant(v: &EncoderVariant) -> bool {
+    matches!(
+        v.variant,
+        VariantStream::Audio(_) | VariantStream::CopyAudio(_)
+    )
+}
 
 mod segment;
 mod variant;
@@ -69,10 +78,73 @@ impl HlsMuxer {
             std::fs::create_dir_all(&out_dir)?;
         }
         let mut vars = Vec::new();
-        for g in encoders {
-            let var = HlsVariant::new(out_dir.clone(), g, segment_type, segment_length)?;
-            //var.enable_low_latency(segment_length / 4.0);
-            vars.push(var);
+        match segment_type {
+            SegmentType::FMP4 => {
+                // CMAF: extract the (deduplicated) audio streams into their own
+                // rendition group so the shared audio track is only stored/served once
+                // instead of being muxed into every video variant. The audio variant's
+                // UUID is unique already, so we use it directly as the rendition group
+                // id (and as the on-disk directory name).
+                let mut audio_seen: Vec<Uuid> = Vec::new();
+                for g in encoders {
+                    for s in g.streams.iter().filter(|s| is_audio_variant(s)) {
+                        let id = s.variant.id();
+                        if audio_seen.contains(&id) {
+                            continue;
+                        }
+                        audio_seen.push(id);
+                        let var = HlsVariant::new(
+                            out_dir.clone(),
+                            id.to_string(),
+                            &[s],
+                            segment_type,
+                            segment_length,
+                            Some(id.to_string()),
+                        )?;
+                        vars.push(var);
+                    }
+                }
+
+                // Create the main (video) variants with audio stripped, each
+                // referencing the shared audio rendition group by its UUID.
+                for g in encoders {
+                    let media: Vec<&EncoderVariant> =
+                        g.streams.iter().filter(|s| !is_audio_variant(s)).collect();
+                    if media.is_empty() {
+                        // pure audio-only group, already handled above
+                        continue;
+                    }
+                    let audio_group = g
+                        .streams
+                        .iter()
+                        .find(|s| is_audio_variant(s))
+                        .map(|s| s.variant.id().to_string());
+                    let var = HlsVariant::new(
+                        out_dir.clone(),
+                        g.id.to_string(),
+                        &media,
+                        segment_type,
+                        segment_length,
+                        audio_group,
+                    )?;
+                    vars.push(var);
+                }
+            }
+            SegmentType::MPEGTS => {
+                // MPEG-TS keeps audio muxed together with video in each variant
+                for g in encoders {
+                    let streams: Vec<&EncoderVariant> = g.streams.iter().collect();
+                    let var = HlsVariant::new(
+                        out_dir.clone(),
+                        g.id.to_string(),
+                        &streams,
+                        segment_type,
+                        segment_length,
+                        None,
+                    )?;
+                    vars.push(var);
+                }
+            }
         }
 
         // force all variants to have the same segment length
@@ -108,11 +180,22 @@ impl HlsMuxer {
 
     fn write_master_playlist(&mut self) -> Result<()> {
         let mut pl = m3u8_rs::MasterPlaylist::default();
-        pl.version = Some(3);
+        // fMP4/CMAF (EXT-X-MAP + audio rendition groups) requires HLS protocol v6+
+        let is_fmp4 = self
+            .variants
+            .iter()
+            .any(|v| v.segment_type == SegmentType::FMP4);
+        pl.version = Some(if is_fmp4 { 6 } else { 3 });
+        // EXT-X-MEDIA entries for shared audio renditions
+        pl.alternatives = self
+            .variants
+            .iter()
+            .filter_map(|v| v.to_alternative_media())
+            .collect();
         pl.variants = self
             .variants
             .iter()
-            .map(|v| v.to_playlist_variant())
+            .filter_map(|v| v.to_playlist_variant())
             .collect();
 
         let mut f_out = File::create(self.out_dir.join(Self::MASTER_PLAYLIST))?;
@@ -180,6 +263,7 @@ impl HlsMuxer {
                         },
                         variant.segment_type,
                     ),
+                    variant.is_audio_only(),
                 ) {
                     remaining_segments.push(egress_segment);
                 }

--- a/crates/core/src/mux/hls/segment.rs
+++ b/crates/core/src/mux/hls/segment.rs
@@ -21,7 +21,12 @@ impl HlsSegment {
     }
 
     /// Convert to EgressSegment with variant ID and path
-    pub fn to_egress_segment(&self, variant_id: Uuid, path: PathBuf) -> Option<EgressSegment> {
+    pub fn to_egress_segment(
+        &self,
+        variant_id: Uuid,
+        path: PathBuf,
+        audio_only: bool,
+    ) -> Option<EgressSegment> {
         match self {
             HlsSegment::Full(seg) => Some(EgressSegment {
                 variant: variant_id,
@@ -29,6 +34,7 @@ impl HlsSegment {
                 duration: seg.duration,
                 path,
                 sha256: seg.sha256,
+                audio_only,
             }),
             HlsSegment::Partial(_) => None, // Partial segments don't have full segment info
         }

--- a/crates/core/src/mux/hls/variant.rs
+++ b/crates/core/src/mux/hls/variant.rs
@@ -1,4 +1,4 @@
-use crate::egress::{EgressResult, EgressSegment, EncoderOrSourceStream, EncoderVariantGroup};
+use crate::egress::{EgressResult, EgressSegment, EncoderOrSourceStream, EncoderVariant};
 use crate::hash_file_sync;
 use crate::mux::hls::segment::{HlsSegment, PartialSegmentInfo, SegmentInfo};
 use crate::mux::{HlsVariantStream, SegmentType};
@@ -12,7 +12,10 @@ use ffmpeg_rs_raw::ffmpeg_sys_the_third::{
 };
 use ffmpeg_rs_raw::{AvPacketRef, Muxer, bail_ffmpeg, cstr};
 use m3u8_rs::Playlist::MediaPlaylist;
-use m3u8_rs::{ExtTag, MediaSegmentType, PartInf, Playlist, PreloadHint};
+use m3u8_rs::{
+    AlternativeMedia, AlternativeMediaType, ExtTag, MediaSegmentType, PartInf, Playlist,
+    PreloadHint,
+};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::{File, create_dir_all};
@@ -58,6 +61,12 @@ pub struct HlsVariant {
     next_partial_independent: bool,
     /// Path to initialization segment for fMP4
     init_segment_path: Option<String>,
+    /// Whether this variant contains a video stream
+    has_video: bool,
+    /// CMAF audio rendition group id.
+    /// - For an audio-only variant this is the group it *provides* (EXT-X-MEDIA GROUP-ID).
+    /// - For a video (main) variant this is the group it *references* (EXT-X-STREAM-INF AUDIO=).
+    audio_group: Option<String>,
 }
 
 impl HlsVariant {
@@ -65,12 +74,12 @@ impl HlsVariant {
 
     pub fn new(
         out_dir: PathBuf,
-        group: &EncoderVariantGroup,
+        name: String,
+        streams_in: &[&EncoderVariant],
         segment_type: SegmentType,
         mut segment_length: f32,
+        audio_group: Option<String>,
     ) -> Result<Self> {
-        let name = group.id.to_string();
-
         let mut segments = Vec::new();
         let var_dir = out_dir.join(&name);
         if !var_dir.exists() {
@@ -116,7 +125,7 @@ impl HlsVariant {
         let mut ref_stream_index = -1;
         let mut has_video = false;
 
-        for g in &group.streams {
+        for g in streams_in.iter().copied() {
             match g.stream {
                 EncoderOrSourceStream::Encoder(enc) => match g.variant {
                     VariantStream::Video(v) => unsafe {
@@ -224,6 +233,8 @@ impl HlsVariant {
             next_partial_independent: false,
             segment_length_target: segment_length,
             init_segment_path: None,
+            has_video,
+            audio_group,
         };
 
         Ok(variant)
@@ -356,8 +367,14 @@ impl HlsVariant {
         let pkt_q = unsafe { av_q2d(pkt.time_base) };
         let mut result = EgressResult::None;
         let stream_type = unsafe { (*(*pkt_stream).codecpar).codec_type };
-        let mut can_split =
-            stream_type == AVMediaType::VIDEO && (pkt.flags & AV_PKT_FLAG_KEY == AV_PKT_FLAG_KEY);
+        // For variants with video we only split on video keyframes. For audio-only
+        // renditions (CMAF audio group) every audio frame is a sync sample so we can
+        // split on any audio packet at a segment boundary.
+        let mut can_split = if self.has_video {
+            stream_type == AVMediaType::VIDEO && (pkt.flags & AV_PKT_FLAG_KEY == AV_PKT_FLAG_KEY)
+        } else {
+            stream_type == AVMediaType::AUDIO
+        };
         let mut is_ref_pkt = stream_index == self.ref_stream_index;
 
         if pkt.pts == AV_NOPTS_VALUE {
@@ -581,6 +598,7 @@ impl HlsVariant {
                 duration: seg.duration,
                 path: self.map_segment_path(seg.index, self.segment_type),
                 sha256: seg.sha256,
+                audio_only: self.is_audio_only(),
             })
             .collect();
 
@@ -595,6 +613,7 @@ impl HlsVariant {
             duration: cur_duration as f32,
             path: completed_seg_path,
             sha256: hash,
+            audio_only: self.is_audio_only(),
         };
 
         self.segments.push(HlsSegment::Full(SegmentInfo {
@@ -773,6 +792,13 @@ impl HlsVariant {
                 }
             }
 
+            // For CMAF the audio is delivered in a separate rendition group, but the
+            // STREAM-INF CODECS attribute must still advertise every codec the variant
+            // depends on, including the referenced audio group.
+            if self.audio_group.is_some() && !codecs.iter().any(|c| c.starts_with("mp4a")) {
+                codecs.push("mp4a.40.2".to_string());
+            }
+
             if codecs.is_empty() {
                 None
             } else {
@@ -781,14 +807,46 @@ impl HlsVariant {
         }
     }
 
-    pub fn to_playlist_variant(&self) -> m3u8_rs::VariantStream {
+    /// True if this variant only carries audio (a CMAF audio rendition).
+    pub fn is_audio_only(&self) -> bool {
+        !self.has_video
+            && self
+                .streams
+                .iter()
+                .any(|s| matches!(s, HlsVariantStream::Audio { .. }))
+    }
+
+    /// Build an EXT-X-MEDIA entry for this variant if it is an audio rendition.
+    pub fn to_alternative_media(&self) -> Option<AlternativeMedia> {
+        let group_id = self.audio_group.clone()?;
+        if !self.is_audio_only() {
+            return None;
+        }
+        Some(AlternativeMedia {
+            media_type: AlternativeMediaType::Audio,
+            uri: Some(format!("{}/{}", self.name, Self::PLAYLIST_NAME)),
+            group_id,
+            name: "audio".to_string(),
+            default: true,
+            autoselect: true,
+            channels: Some("2".to_string()),
+            ..Default::default()
+        })
+    }
+
+    /// Build the EXT-X-STREAM-INF entry for this variant.
+    /// Returns `None` for audio-only renditions (they are emitted as EXT-X-MEDIA instead).
+    pub fn to_playlist_variant(&self) -> Option<m3u8_rs::VariantStream> {
+        if self.is_audio_only() {
+            return None;
+        }
         unsafe {
             let pes = self.video_stream().unwrap_or(self.streams.first().unwrap());
             let av_stream = *(*self.mux.context()).streams.add(pes.index());
             let codec_par = (*av_stream).codecpar;
             let bitrate = (*codec_par).bit_rate as u64;
             let fps = av_q2d((*codec_par).framerate);
-            m3u8_rs::VariantStream {
+            Some(m3u8_rs::VariantStream {
                 is_i_frame: false,
                 uri: format!("{}/{}", self.name, Self::PLAYLIST_NAME),
                 bandwidth: if bitrate == 0 {
@@ -810,12 +868,12 @@ impl HlsVariant {
                 }),
                 frame_rate: if fps > 0.0 { Some(fps) } else { None },
                 hdcp_level: None,
-                audio: None,
+                audio: self.audio_group.clone(),
                 video: None,
                 subtitles: None,
                 closed_captions: None,
                 other_attributes: None,
-            }
+            })
         }
     }
 }

--- a/crates/core/src/test_hls_timing.rs
+++ b/crates/core/src/test_hls_timing.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "debug-hls")]
-use crate::egress::EncoderOrSourceStream;
+use crate::egress::{EncoderOrSourceStream, EncoderVariant, EncoderVariantGroup};
 use crate::generator::FrameGenerator;
 use crate::mux::{HlsMuxer, SegmentType};
 use crate::variant::{AudioVariant, VariantStream, VideoVariant};
@@ -213,12 +213,15 @@ impl HlsTimingTester {
             bitrate: 1_000_000,
             codec: "libx264".to_string(),
             preset: Some("fast".to_string()),
-            profile: Some("main".to_string()),
+            profile: AV_PROFILE_H264_MAIN as u32,
             level: 51,
             gop: (VIDEO_FPS * 2.0) as _,
             pixel_format: "yuv420p".to_string(),
             tune: None,
             max_b_frames: 0,
+            color_space: "bt709".to_string(),
+            color_range: "tv".to_string(),
+            scale_mode: None,
         };
 
         let audio_stream = AudioVariant {
@@ -233,24 +236,23 @@ impl HlsTimingTester {
 
         let video_variant = VariantStream::Video(video_stream.clone());
         let audio_variant = VariantStream::Audio(audio_stream.clone());
-        let variants = vec![
-            (
-                &video_variant,
-                EncoderOrSourceStream::Encoder(&video_encoder),
-            ),
-            (
-                &audio_variant,
-                EncoderOrSourceStream::Encoder(&audio_encoder),
-            ),
-        ];
+        let groups = vec![EncoderVariantGroup {
+            id: Uuid::new_v4(),
+            streams: vec![
+                EncoderVariant {
+                    variant: &video_variant,
+                    stream: EncoderOrSourceStream::Encoder(&video_encoder),
+                },
+                EncoderVariant {
+                    variant: &audio_variant,
+                    stream: EncoderOrSourceStream::Encoder(&audio_encoder),
+                },
+            ],
+        }];
 
         // Create HLS muxer
-        let mut hls_muxer = HlsMuxer::new(
-            output_dir.to_path_buf(),
-            variants.into_iter(),
-            segment_type,
-            2.0,
-        )?;
+        let mut hls_muxer = HlsMuxer::new(output_dir.to_path_buf(), &groups, segment_type, 2.0)?;
+        hls_muxer.open()?;
 
         // Create frame generator
         let frame_size = unsafe { (*audio_encoder.codec_context()).frame_size as _ };
@@ -408,16 +410,36 @@ impl HlsTimingTester {
     }
 
     fn test_stream_timing_internal(&self, hls_dir: &Path) -> Result<HlsTimingTestResult> {
-        let playlist_path = hls_dir.join("live.m3u8");
+        let top_path = hls_dir.join("live.m3u8");
 
-        if !playlist_path.exists() {
+        if !top_path.exists() {
             return Err(anyhow::anyhow!(
                 "Playlist file does not exist: {:?}",
-                playlist_path
+                top_path
             ));
         }
 
-        // Parse the playlist
+        // The top-level live.m3u8 is a master playlist. Resolve it down to the
+        // first video variant's media playlist (which is what carries segments).
+        let top_raw = fs::read(&top_path).context("Failed to read playlist file")?;
+        let (hls_dir, playlist_path) = match m3u8_rs::parse_playlist_res(&top_raw) {
+            Ok(m3u8_rs::Playlist::MasterPlaylist(master)) => {
+                let variant = master
+                    .variants
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("master playlist has no variants"))?;
+                let media_path = hls_dir.join(&variant.uri);
+                let base = media_path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| hls_dir.to_path_buf());
+                (base, media_path)
+            }
+            _ => (hls_dir.to_path_buf(), top_path.clone()),
+        };
+        let hls_dir = hls_dir.as_path();
+
+        // Parse the (variant) media playlist
         let playlist_content =
             fs::read_to_string(&playlist_path).context("Failed to read playlist file")?;
 
@@ -856,6 +878,84 @@ mod tests {
                 panic!("Test generation failed: {}", e);
             }
         }
+    }
+
+    /// Verify that fMP4 output produces a proper CMAF layout:
+    /// - a master playlist with an EXT-X-MEDIA audio rendition group
+    /// - a video variant that references the audio group (and carries no audio itself)
+    /// - a separate shared audio rendition playlist + init segment
+    #[ignore]
+    #[test]
+    fn test_cmaf_audio_grouping() {
+        tracing_subscriber::fmt::try_init().ok();
+
+        let temp_dir = tempdir().unwrap();
+        let tester = HlsTimingTester::new(0.2, 1.0, 0.5);
+
+        let (_muxer, out_dir) = tester
+            .generate_test_stream(temp_dir.path(), 8.0, SegmentType::FMP4)
+            .expect("generation failed");
+
+        // Top-level live.m3u8 must be a master playlist
+        let master_raw = fs::read(out_dir.join("live.m3u8")).unwrap();
+        let master = match m3u8_rs::parse_playlist_res(&master_raw) {
+            Ok(m3u8_rs::Playlist::MasterPlaylist(m)) => m,
+            other => panic!("expected master playlist, got {:?}", other),
+        };
+
+        // There must be exactly one audio rendition group
+        let audio_alts: Vec<_> = master
+            .alternatives
+            .iter()
+            .filter(|a| a.media_type == m3u8_rs::AlternativeMediaType::Audio)
+            .collect();
+        assert_eq!(audio_alts.len(), 1, "expected one audio rendition group");
+        let audio_alt = audio_alts[0];
+        let audio_uri = audio_alt.uri.clone().expect("audio rendition needs URI");
+
+        // Exactly one video variant, referencing the audio group, codecs listing audio
+        assert_eq!(master.variants.len(), 1, "expected one video variant");
+        let video = &master.variants[0];
+        assert_eq!(
+            video.audio.as_deref(),
+            Some(audio_alt.group_id.as_str()),
+            "video variant must reference the audio group"
+        );
+        let codecs = video.codecs.clone().unwrap_or_default();
+        assert!(
+            codecs.contains("avc1") && codecs.contains("mp4a"),
+            "video CODECS must advertise both video and audio: {}",
+            codecs
+        );
+
+        // The audio rendition playlist + init segment exist and are separate from video
+        let audio_pl_path = out_dir.join(&audio_uri);
+        assert!(audio_pl_path.exists(), "audio playlist missing: {:?}", audio_pl_path);
+        let audio_dir = audio_pl_path.parent().unwrap();
+        assert!(audio_dir.join("init.mp4").exists(), "audio init segment missing");
+        assert_ne!(
+            audio_dir,
+            out_dir.join(&video.uri).parent().unwrap(),
+            "audio and video renditions must live in separate directories"
+        );
+
+        // Audio playlist must contain fMP4 segments and an EXT-X-MAP
+        let audio_pl_raw = fs::read(&audio_pl_path).unwrap();
+        let audio_pl = match m3u8_rs::parse_playlist_res(&audio_pl_raw) {
+            Ok(m3u8_rs::Playlist::MediaPlaylist(m)) => m,
+            other => panic!("expected audio media playlist, got {:?}", other),
+        };
+        let audio_segs = audio_pl
+            .segments
+            .iter()
+            .filter(|s| matches!(s, MediaSegmentType::Full(_)))
+            .count();
+        assert!(audio_segs > 0, "audio rendition should have segments");
+
+        println!(
+            "✓ CMAF audio grouping: group={}, audio_uri={}, video_codecs={}, audio_segs={}",
+            audio_alt.group_id, audio_uri, codecs, audio_segs
+        );
     }
 
     #[ignore]

--- a/crates/zap-stream/src/overseer.rs
+++ b/crates/zap-stream/src/overseer.rs
@@ -1039,8 +1039,13 @@ fn into_n94_segment(seg: &EgressSegment) -> N94Segment {
 }
 
 fn get_cost(endpoint: &IngestEndpoint, segments: &[EgressSegment]) -> (f32, i64) {
-    // count total duration from all segments (including copied)
-    let duration = segments.iter().fold(0.0, |acc, v| acc + v.duration);
+    // count total duration from all video segments (including copied).
+    // Audio-only renditions (CMAF audio group) are shared across all video
+    // variants and are not billed separately.
+    let duration = segments
+        .iter()
+        .filter(|v| !v.audio_only)
+        .fold(0.0, |acc, v| acc + v.duration);
 
     let cost_per_minute = endpoint.cost;
 
@@ -1079,6 +1084,7 @@ mod tests {
             duration,
             path: PathBuf::from("/test"),
             sha256: [0u8; 32],
+            audio_only: false,
         }
     }
 


### PR DESCRIPTION
Closes #29

## Summary

Implements CMAF streaming for the HLS muxer by splitting the shared audio track into its own **CMAF audio rendition group** instead of muxing it into every video variant's segments.

Previously each video rendition (720p, 480p, …) muxed the *shared* audio into its own segments, so identical audio bytes were stored and served N times. Now, for fMP4 output, audio is stored/served **once** and referenced by every video variant via `EXT-X-MEDIA` — much more efficient output.

## What changed

- **`HlsVariant::new`** now takes an explicit `name` + stream slice + `audio_group`, so a variant can be video-only or audio-only. Audio-only renditions split segments on audio frames (every AAC frame is a sync sample) instead of requiring a video keyframe.
- Audio-only variants emit `EXT-X-MEDIA TYPE=AUDIO`; video variants reference the group via `AUDIO=` and advertise the audio codec in `CODECS`.
- The **audio variant UUID** is used directly as both the rendition group id and the on-disk directory name.
- **Billing:** the audio rendition is shared, so it is not billed separately. `EgressSegment` gains an `audio_only` flag and `get_cost()` skips audio-only segments. Audio segments are still emitted (so they publish via n94 and get cleaned up).
- **MPEGTS output is unchanged** (audio stays muxed in).

## Example output

Master `live.m3u8`:
- `EXT-X-MEDIA TYPE=AUDIO,GROUP-ID="<audio-uuid>",URI="<audio-uuid>/live.m3u8"`
- Video variant: `AUDIO="<audio-uuid>"`, `CODECS="avc1.4d0033,mp4a.40.2"`

Audio lives in its own directory with its own `init.mp4` + `.m4s` segments.

## Testing

- Added `test_cmaf_audio_grouping` (under `debug-hls`) which verifies the CMAF master/rendition layout — passes.
- Revived the stale `debug-hls` test harness (it no longer compiled against the current `EncoderVariantGroup` API) and fixed the timing analyzer to follow the master → variant playlist indirection.

> Note: some pre-existing failures on `main` are unrelated to this change (the `n94` binary build, a couple of `runner.rs`/`config.rs` clippy deny-lints, and `test_get_multi_track_config_linux_nvidia`).