### PR TITLE
fix(hls): enable and complete LL-HLS playback

### DIFF
--- a/crates/core/src/mux/hls/mod.rs
+++ b/crates/core/src/mux/hls/mod.rs
@@ -70,8 +70,13 @@ impl HlsMuxer {
         }
         let mut vars = Vec::new();
         for g in encoders {
-            let var = HlsVariant::new(out_dir.clone(), g, segment_type, segment_length)?;
-            //var.enable_low_latency(segment_length / 4.0);
+            let mut var = HlsVariant::new(out_dir.clone(), g, segment_type, segment_length)?;
+            // Low-latency HLS requires byte-range addressable partial segments; we only
+            // enable it for fMP4 output where partial fragments are well supported by players.
+            if segment_type == SegmentType::FMP4 {
+                let part_target = var.partial_segment_length();
+                var.enable_low_latency(part_target);
+            }
             vars.push(var);
         }
 
@@ -108,7 +113,8 @@ impl HlsMuxer {
 
     fn write_master_playlist(&mut self) -> Result<()> {
         let mut pl = m3u8_rs::MasterPlaylist::default();
-        pl.version = Some(3);
+        // Version 6 is required for fMP4 / LL-HLS aware clients
+        pl.version = Some(6);
         pl.variants = self
             .variants
             .iter()

--- a/crates/core/src/mux/hls/variant.rs
+++ b/crates/core/src/mux/hls/variant.rs
@@ -325,10 +325,15 @@ impl HlsVariant {
         self.segment_length_target.max(2.0)
     }
 
+    /// Target duration of a single partial segment (LL-HLS `PART-TARGET`).
+    ///
+    /// We aim for ~4 partials per full segment which keeps `PART-HOLD-BACK`
+    /// (3x part target) comfortably below the full segment duration while still
+    /// producing reasonably sized fragments.
     pub fn partial_segment_length(&self) -> f32 {
-        let seg_size = self.segment_length();
-        let partial_seg_size = seg_size / 3.0; // 3 segments min
-        partial_seg_size - partial_seg_size % seg_size
+        // clamp to a sane minimum so very short segment lengths don't produce
+        // absurdly tiny fragments
+        (self.segment_length() / 4.0).max(0.2)
     }
 
     pub fn segment_name(t: SegmentType, idx: u64) -> String {
@@ -695,6 +700,21 @@ impl HlsVariant {
             pl.unknown_tags.push(ExtTag {
                 tag: "X-MAP".to_string(),
                 rest: Some(format!("URI=\"{}\"", init_path)),
+            });
+        }
+
+        // LL-HLS: advertise blocking playlist reload + partial hold back so that
+        // players actually enter low-latency mode. PART-HOLD-BACK must be at least
+        // 3x the partial target duration per RFC 8216 (LL-HLS).
+        if self.low_latency {
+            let part_hold_back =
+                (self.partial_target_duration * 3.0).max(self.partial_target_duration + 0.1);
+            pl.unknown_tags.push(ExtTag {
+                tag: "X-SERVER-CONTROL".to_string(),
+                rest: Some(format!(
+                    "PART-HOLD-BACK={:.3},CAN-BLOCK-RELOAD=YES",
+                    part_hold_back
+                )),
             });
         }
 

--- a/crates/zap-stream/src/http/hls.rs
+++ b/crates/zap-stream/src/http/hls.rs
@@ -95,17 +95,105 @@ impl HlsRouter {
             .base_path
             .join(&stream_id)
             .join(HLS_EGRESS_PATH)
-            .join(variant)
+            .join(&variant)
             .join("live.m3u8");
 
-        let stream = FileStream::from_path(&playlist_path)
-            .await
-            .map_err(|_| (StatusCode::NOT_FOUND, "File not found"))?;
-        this.stream_manager.track_viewer(&stream_id, &q.vt).await;
-        let mut rsp = stream.into_response();
-        rsp.headers_mut()
-            .insert("content-type", Self::PLAYLIST_CONTENT_TYPE.parse().unwrap());
-        Ok(rsp)
+        if let Some(vt) = q.vt.as_deref() {
+            this.stream_manager.track_viewer(&stream_id, vt).await;
+        }
+
+        // LL-HLS blocking playlist reload (RFC 8216, Part 6.2.5.2):
+        // when the client asks for a future media-sequence-number / part via
+        // `_HLS_msn` and `_HLS_part`, hold the request until the playlist on disk
+        // actually contains that part (or we time out). This is what lets players
+        // run at sub-segment latency instead of polling.
+        let content = if q.hls_msn.is_some() {
+            Self::read_playlist_blocking(&playlist_path, q.hls_msn, q.hls_part)
+                .await
+                .map_err(|_| (StatusCode::NOT_FOUND, "File not found"))?
+        } else {
+            tokio::fs::read(&playlist_path)
+                .await
+                .map_err(|_| (StatusCode::NOT_FOUND, "File not found"))?
+        };
+
+        let headers = [
+            (CONTENT_TYPE, Self::PLAYLIST_CONTENT_TYPE),
+            // playlists are live and must never be cached by intermediaries
+            (axum::http::header::CACHE_CONTROL, "no-cache, no-store"),
+        ];
+        Ok((headers, content).into_response())
+    }
+
+    /// Block until the variant playlist contains the requested (msn, part), then
+    /// return its bytes. Falls back to whatever is current after a short timeout
+    /// so a client is never left hanging if the stream stalls or ends.
+    async fn read_playlist_blocking(
+        path: &std::path::Path,
+        want_msn: Option<u64>,
+        want_part: Option<u64>,
+    ) -> Result<Vec<u8>> {
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        // Bound the wait. Players re-issue the blocking request, so a modest cap
+        // keeps connections from piling up while still covering a full segment.
+        let deadline = Instant::now() + Duration::from_secs(6);
+        let want_msn = want_msn.unwrap_or(0);
+        let want_part = want_part.unwrap_or(0);
+
+        loop {
+            let content = tokio::fs::read(path).await?;
+            if Self::playlist_has_part(&content, want_msn, want_part) || Instant::now() >= deadline {
+                return Ok(content);
+            }
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        }
+    }
+
+    /// Returns true when the playlist already contains the requested part, i.e.
+    /// the requested (msn, part) is <= the most recent part advertised.
+    fn playlist_has_part(content: &[u8], want_msn: u64, want_part: u64) -> bool {
+        let (_, pl) = match m3u8_rs::parse_playlist(content) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        let pl = match pl {
+            m3u8_rs::Playlist::MediaPlaylist(pl) => pl,
+            // master playlist can't carry parts; don't block
+            m3u8_rs::Playlist::MasterPlaylist(_) => return true,
+        };
+
+        // MSN of the first listed full segment
+        let media_sequence = pl.media_sequence;
+        // Count full segments and the partial segments that trail the last full one.
+        let mut full_count: u64 = 0;
+        let mut trailing_parts: u64 = 0;
+        for seg in &pl.segments {
+            match seg {
+                m3u8_rs::MediaSegmentType::Full(_) => {
+                    full_count += 1;
+                    trailing_parts = 0;
+                }
+                m3u8_rs::MediaSegmentType::Partial(_) => {
+                    trailing_parts += 1;
+                }
+                m3u8_rs::MediaSegmentType::PreloadHint(_) => {}
+            }
+        }
+
+        // The in-progress segment (the one currently accumulating parts) has this MSN
+        let in_progress_msn = media_sequence + full_count;
+        if want_msn < in_progress_msn {
+            // A later segment has already begun, so every part of `want_msn` exists.
+            return true;
+        }
+        if want_msn == in_progress_msn {
+            // available part indices are 0..trailing_parts-1
+            return trailing_parts > want_part;
+        }
+        // requested a segment we haven't started yet
+        false
     }
 
     async fn get_segment(
@@ -227,5 +315,76 @@ impl HlsRouter {
 
 #[derive(Deserialize)]
 struct ViewerTokenQuery {
-    pub vt: String,
+    #[serde(default)]
+    pub vt: Option<String>,
+    /// LL-HLS blocking reload: media sequence number being requested
+    #[serde(rename = "_HLS_msn", default)]
+    pub hls_msn: Option<u64>,
+    /// LL-HLS blocking reload: partial segment index within `_HLS_msn`
+    #[serde(rename = "_HLS_part", default)]
+    pub hls_part: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A representative LL-HLS media playlist: media-sequence 10, two full
+    /// segments (MSN 10, 11) followed by the in-progress segment (MSN 12) that
+    /// currently has 2 published parts plus a preload hint for the third.
+    const LL_PLAYLIST: &str = "#EXTM3U\n\
+#EXT-X-VERSION:6\n\
+#EXT-X-TARGETDURATION:2\n\
+#EXT-X-MEDIA-SEQUENCE:10\n\
+#EXT-X-MAP:URI=\"init.mp4\"\n\
+#EXT-X-PART-INF:PART-TARGET=0.5\n\
+#EXT-X-SERVER-CONTROL:PART-HOLD-BACK=1.500,CAN-BLOCK-RELOAD=YES\n\
+#EXTINF:2,\n10.m4s\n\
+#EXTINF:2,\n11.m4s\n\
+#EXT-X-PART:DURATION=0.5,URI=\"12.m4s\",BYTERANGE=\"100@0\",INDEPENDENT=YES\n\
+#EXT-X-PART:DURATION=0.5,URI=\"12.m4s\",BYTERANGE=\"100@100\"\n\
+#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"12.m4s\",BYTERANGE-START=200\n";
+
+    #[test]
+    fn ll_playlist_parses() {
+        // The tags we emit must round-trip through the parser the server itself uses.
+        let (_, pl) = m3u8_rs::parse_playlist(LL_PLAYLIST.as_bytes()).expect("valid playlist");
+        assert!(matches!(pl, m3u8_rs::Playlist::MediaPlaylist(_)));
+    }
+
+    #[test]
+    fn part_already_available_returns_true() {
+        // in-progress segment is MSN 12 with parts 0 and 1 available
+        assert!(HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 12, 0));
+        assert!(HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 12, 1));
+    }
+
+    #[test]
+    fn earlier_segment_is_always_available() {
+        // any part of an already-completed segment is available
+        assert!(HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 11, 99));
+        assert!(HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 10, 0));
+    }
+
+    #[test]
+    fn future_part_blocks() {
+        // part 2 of MSN 12 has not been published yet (only 0,1 exist)
+        assert!(!HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 12, 2));
+        // an entire future segment is not available
+        assert!(!HlsRouter::playlist_has_part(LL_PLAYLIST.as_bytes(), 13, 0));
+    }
+
+    #[test]
+    fn invalid_playlist_does_not_unblock() {
+        assert!(!HlsRouter::playlist_has_part(b"not a playlist", 0, 0));
+    }
+
+    #[test]
+    fn add_token_to_url_appends_correctly() {
+        assert_eq!(HlsRouter::add_token_to_url("a/live.m3u8", "tok"), "a/live.m3u8?vt=tok");
+        assert_eq!(
+            HlsRouter::add_token_to_url("a/live.m3u8?x=1", "tok"),
+            "a/live.m3u8?x=1&vt=tok"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #10

## Problem

LL-HLS was implemented in the codebase but **disabled and incomplete**, which is why streams sat at ~10–15s latency:

- `enable_low_latency(...)` was commented out, so only standard 2s-segment HLS was produced.
- No `#EXT-X-SERVER-CONTROL` tag, so players never entered low-latency mode even when parts existed.
- The HTTP server ignored `_HLS_msn`/`_HLS_part`, forcing clients to poll (the main latency killer).
- `partial_segment_length()` always evaluated to `0` due to a bad modulo.

## Changes

**`mux/hls/mod.rs`**
- Enable LL-HLS for fMP4 variants (production default); bump master playlist to v6.

**`mux/hls/variant.rs`**
- Fix `partial_segment_length()` → ~4 partials per segment (0.5s parts at 2s segments).
- Emit `#EXT-X-SERVER-CONTROL:PART-HOLD-BACK=…,CAN-BLOCK-RELOAD=YES` (≥3× part target per RFC 8216).

**`http/hls.rs`**
- Implement **blocking playlist reload** (`_HLS_msn`/`_HLS_part`): hold the request until the requested part is published (6s cap, 30ms poll) instead of polling.
- Make `vt` optional so LL query params don't break viewer tracking; add `no-cache` on live playlists.
- Add 6 unit tests covering the blocking decision logic and LL playlist round-tripping.

## Result

Latency target drops from ~10–15s to ~`PART-HOLD-BACK` (1.5–2s) for fMP4 streams. MPEG-TS stays standard HLS. Changes are backwards compatible — non-LL players ignore the new tags.

## Testing

- `cargo test -p zap-stream --lib http::hls` — 6/6 passing.
- `cargo build -p zap-stream-core --features egress-hls,pipeline` and `cargo build -p zap-stream` — clean.

### Still needs browser verification (the issue checklist)
Unit-tested at the logic level, but the issue is about real browser playback. Please confirm with a live fMP4 stream on Chrome / Firefox / Safari / Android / iOS.

> Note: the `EXT-X-PRELOAD-HINT` byte-range request for not-yet-written bytes currently returns 416 rather than being held open. Players recover via the blocking playlist reload, so it's not a playback blocker, but request-level part blocking can be added for strict Apple spec compliance.