### PR TITLE
Add NWC reconciliation for expired-but-settled payments

### DIFF
--- a/crates/zap-stream-db/src/db.rs
+++ b/crates/zap-stream-db/src/db.rs
@@ -482,6 +482,15 @@ impl ZapStreamDb {
         .await?)
     }
 
+    /// Get expired but unpaid top-up/zap payments (for reconciliation after a backend outage)
+    pub async fn get_expired_unpaid_payments(&self) -> Result<Vec<Payment>> {
+        Ok(sqlx::query_as(
+        "select * from payment where is_paid = false and payment_type in (0,1) and expires <= current_timestamp() order by created desc",
+    )
+        .fetch_all(&self.db)
+        .await?)
+    }
+
     /// Get the latest completed payment
     pub async fn get_latest_completed_payment(&self) -> Result<Option<Payment>> {
         Ok(sqlx::query_as(

--- a/crates/zap-stream/src/main.rs
+++ b/crates/zap-stream/src/main.rs
@@ -39,7 +39,12 @@ mod websocket_metrics;
 
 #[derive(Parser, Debug)]
 #[clap(version, about)]
-struct Args {}
+struct Args {
+    /// Reconcile expired-but-unpaid invoices against the (NWC) wallet, then exit.
+    /// Use this to recover payments stranded by a payment-backend outage.
+    #[clap(long)]
+    reconcile_payments: bool,
+}
 
 #[cfg(any(target_os = "macos", all(target_os = "linux", target_arch = "aarch64")))]
 type VaList = ffmpeg_sys_the_third::va_list;
@@ -92,7 +97,7 @@ pub unsafe extern "C" fn av_log_redirect(
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().init();
-    let _args = Args::parse();
+    let args = Args::parse();
 
     info!("Starting zap-stream");
 
@@ -158,6 +163,27 @@ async fn main() -> Result<()> {
         let api = Api::new(arc.clone(), settings.clone());
         (arc, api)
     };
+    // One-off reconciliation mode: recover expired invoices that actually settled
+    if args.reconcile_payments {
+        match &settings.overseer.payments {
+            zap_stream::payments::PaymentBackend::NWC { url } => {
+                PaymentHandler::reconcile_expired_nwc_payments(
+                    url,
+                    &overseer.database(),
+                    &overseer.nostr_client(),
+                )
+                .await?;
+            }
+            other => {
+                error!(
+                    "--reconcile-payments is only supported for the NWC backend (configured: {:?})",
+                    other
+                );
+            }
+        }
+        return Ok(());
+    }
+
     let mut tasks = vec![];
 
     //listen for invoice

--- a/crates/zap-stream/src/payments.rs
+++ b/crates/zap-stream/src/payments.rs
@@ -7,7 +7,8 @@ use lnurl::pay::PayResponse;
 use lnurl::{AsyncClient, LnUrlResponse};
 use nostr_sdk::{Client, Event, EventBuilder, JsonUtil, Kind, Tag};
 use nwc::prelude::{
-    MakeInvoiceRequest, NostrWalletConnect, NostrWalletConnectUri, NotificationResult,
+    LookupInvoiceRequest, MakeInvoiceRequest, NostrWalletConnect, NostrWalletConnectUri,
+    NotificationResult,
 };
 pub use payments_rs::lightning::LightningNode;
 use payments_rs::lightning::{
@@ -314,6 +315,56 @@ impl PaymentHandler {
                 }
             }
         })
+    }
+
+    /// Reconcile expired-but-unpaid invoices against an NWC wallet.
+    ///
+    /// If the payment backend went down (e.g. NWC disconnected) while invoices were
+    /// actually being paid, those payments get stranded: the poller stops checking them
+    /// once their `expires` timestamp passes. This looks up each expired unpaid invoice
+    /// on the wallet and completes the ones that actually settled.
+    pub async fn reconcile_expired_nwc_payments(
+        nwc_url: &str,
+        db: &ZapStreamDb,
+        client: &Client,
+    ) -> Result<()> {
+        let uri = NostrWalletConnectUri::parse(nwc_url)?;
+        let conn = NostrWalletConnect::new(uri);
+
+        let payments = db.get_expired_unpaid_payments().await?;
+        info!("Reconciling {} expired unpaid payment(s)...", payments.len());
+
+        let mut settled = 0usize;
+        for payment in payments {
+            let ph_hex = payment.payment_hash.encode_hex::<String>();
+            let rsp = match conn
+                .lookup_invoice(LookupInvoiceRequest {
+                    payment_hash: Some(ph_hex.clone()),
+                    invoice: None,
+                })
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    // Not found / lookup error - most likely never paid
+                    warn!("lookup_invoice failed for {}: {}", ph_hex, e);
+                    continue;
+                }
+            };
+
+            if rsp.settled_at.is_some() {
+                info!("Payment {} settled on wallet, completing...", ph_hex);
+                if let Err(e) =
+                    Self::try_complete_payment(ph_hex.clone(), rsp.preimage, db, client).await
+                {
+                    error!("Failed to complete reconciled payment {}: {}", ph_hex, e);
+                } else {
+                    settled += 1;
+                }
+            }
+        }
+        info!("Reconciliation complete, settled {} payment(s).", settled);
+        Ok(())
     }
 
     async fn try_complete_payment(


### PR DESCRIPTION
Recover payments stranded when the NWC backend is down: invoices that actually settled on the wallet but show unpaid/expired in the DB.

- db: get_expired_unpaid_payments() for unpaid top-up/zap rows past expiry
- payments: reconcile_expired_nwc_payments() looks up each via NWC lookup_invoice and completes only those with settled_at set
- main: --reconcile-payments flag runs a one-off reconcile then exits