### PR TITLE
Point m3u8-rs at github.com/v0l/m3u8-rs (git.v0l.io down)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ dependencies = [
  "js-sys",
  "log 0.4.28",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2763,7 +2763,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "m3u8-rs"
 version = "6.0.0"
-source = "git+https://git.v0l.io/Kieran/m3u8-rs.git?rev=6803eefca2838a8bfae9e19fd516ef36d7d89997#6803eefca2838a8bfae9e19fd516ef36d7d89997"
+source = "git+https://github.com/v0l/m3u8-rs.git?branch=hls-ll#6803eefca2838a8bfae9e19fd516ef36d7d89997"
 dependencies = [
  "chrono",
  "nom",
@@ -6581,7 +6581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6593,7 +6593,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6610,25 +6610,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6673,7 +6660,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ url = "2"
 itertools = "0.14"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
-m3u8-rs = { git = "https://git.v0l.io/Kieran/m3u8-rs.git", rev = "6803eefca2838a8bfae9e19fd516ef36d7d89997" }
+m3u8-rs = { git = "https://github.com/v0l/m3u8-rs.git", branch = "hls-ll" }
 sha2 = "0.10"
 data-encoding = "2.9"
 rand = "0.9"


### PR DESCRIPTION
git.v0l.io is returning HTTP 524, breaking builds. Switches the workspace m3u8-rs dependency to the GitHub mirror `v0l/m3u8-rs` on the `hls-ll` branch.

- Same commit (`6803eefc`) that was previously pinned via rev, so no code behavior change.
- `hls-ll` carries the LL-HLS `Part`/`MediaSegmentType`/byte-range APIs that `crates/core/src/mux/hls` depends on (master lacks them).
- Uses `branch = "hls-ll"` instead of a pinned rev.

Verified `cargo check -p zap-stream` builds.