### PR TITLE
fix(hls): LL-HLS stability fixes

### DIFF
--- a/crates/core/src/mux/hls/mod.rs
+++ b/crates/core/src/mux/hls/mod.rs
@@ -147,15 +147,6 @@ impl HlsMuxer {
             }
         }
 
-        // Low-latency HLS requires byte-range addressable partial segments; we only
-        // enable it for fMP4 output where partial fragments are well supported by players.
-        if segment_type == SegmentType::FMP4 {
-            for var in vars.iter_mut() {
-                let part_target = var.partial_segment_length();
-                var.enable_low_latency(part_target);
-            }
-        }
-
         // force all variants to have the same segment length
         if let Some(max_seg_duration) = vars
             .iter()
@@ -170,6 +161,17 @@ impl HlsMuxer {
             );
             vars.iter_mut()
                 .for_each(|s| s.segment_length_target = max_seg_duration);
+        }
+
+        // Low-latency HLS requires byte-range addressable partial segments; we only
+        // enable it for fMP4 output where partial fragments are well supported by players.
+        // This must happen AFTER segment lengths are forced equal so every variant
+        // derives its PART-TARGET from the same (final) segment length.
+        if segment_type == SegmentType::FMP4 {
+            for var in vars.iter_mut() {
+                let part_target = var.partial_segment_length();
+                var.enable_low_latency(part_target);
+            }
         }
 
         Ok(Self {

--- a/crates/core/src/mux/hls/variant.rs
+++ b/crates/core/src/mux/hls/variant.rs
@@ -14,7 +14,6 @@ use ffmpeg_rs_raw::{AvPacketRef, Muxer, bail_ffmpeg, cstr};
 use m3u8_rs::Playlist::MediaPlaylist;
 use m3u8_rs::{
     AlternativeMedia, AlternativeMediaType, ExtTag, MediaSegmentType, PartInf, Playlist,
-    PreloadHint,
 };
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -45,7 +44,8 @@ pub struct HlsVariant {
     pub(crate) segment_type: SegmentType,
     /// Timestamp of the start of the current segment
     current_segment_start: f64,
-    /// Timestamp of the start of the current partial
+    /// Timestamp of the start of the current partial (DTS timeline; packets
+    /// arrive in decode order so DTS is the only monotonic clock available)
     current_partial_start: f64,
     /// Number of packets written to current segment
     packets_written: u64,
@@ -271,7 +271,6 @@ impl HlsVariant {
             Playlist::MasterPlaylist(_) => bail!("Invalid MasterPlaylist, expected MediaPlaylist"),
             MediaPlaylist(pl) => {
                 let mut idx_ctr = pl.media_sequence;
-                let mut partial_ctr = 1;
                 let mut ret = Vec::new();
 
                 // map HLS segments from playlist back into internal structs
@@ -294,25 +293,14 @@ impl HlsVariant {
                                     .unwrap_or_default(),
                             });
                             idx_ctr += 1;
-                            partial_ctr = 1; // always reset on full segment
                             full_seg
                         }
-                        MediaSegmentType::Partial(p) => {
-                            let part_seg = HlsSegment::Partial(PartialSegmentInfo {
-                                index: partial_ctr, //assume order is correct
-                                parent_index: idx_ctr,
-                                // we use byte-range style, so filename always is the same as full segment name
-                                parent_kind: if p.uri.ends_with(".ts") {
-                                    SegmentType::MPEGTS
-                                } else {
-                                    SegmentType::FMP4
-                                },
-                                duration: p.duration,
-                                independent: p.independent,
-                                byte_range: p.byte_range.as_ref().map(|r| (r.length, r.offset)),
-                            });
-                            partial_ctr += 1;
-                            part_seg
+                        MediaSegmentType::Partial(_) => {
+                            // Drop stale partial segments: they reference byte ranges of a
+                            // file from the previous run which the new stream will overwrite.
+                            // Keeping them corrupts the byte-range chain (and can underflow
+                            // the next partial's size computation).
+                            continue;
                         }
                         MediaSegmentType::PreloadHint(_) => {
                             // ignore
@@ -358,6 +346,23 @@ impl HlsVariant {
         self.out_dir.join(Self::segment_name(typ, idx))
     }
 
+    /// Whether writing the next packet would push the current partial segment past
+    /// `PART-TARGET`. Per the LL-HLS spec no part may exceed the advertised
+    /// PART-TARGET, so the part must be closed *before* the packet that would
+    /// cross the boundary. Falls back to closing once the target is reached when
+    /// the packet duration is unknown.
+    pub(crate) fn partial_would_exceed_target(
+        cur_part_duration: f64,
+        next_pkt_duration: f64,
+        target: f64,
+    ) -> bool {
+        if next_pkt_duration > 0.0 {
+            cur_part_duration + next_pkt_duration > target
+        } else {
+            cur_part_duration >= target
+        }
+    }
+
     /// Process a single packet through the muxer
     pub(crate) fn process_packet(
         &mut self,
@@ -399,17 +404,34 @@ impl HlsVariant {
         }
         if is_ref_pkt && self.packets_written > 0 {
             let pkt_pts = pkt.pts as f64 * pkt_q;
+            // Partial segments are tracked on the DTS timeline: packets arrive in
+            // decode order, and with B-frames the PTS is non-monotonic and can jump
+            // more than one frame ahead, which would overshoot PART-TARGET.
+            let pkt_dts = if pkt.dts == AV_NOPTS_VALUE {
+                pkt_pts
+            } else {
+                pkt.dts as f64 * pkt_q
+            };
+            let pkt_duration = pkt.duration as f64 * pkt_q;
             let cur_duration = pkt_pts - self.current_segment_start;
-            let cur_part_duration = pkt_pts - self.current_partial_start;
+            let cur_part_duration = pkt_dts - self.current_partial_start;
 
             let should_end_this_segment = cur_duration >= self.segment_length() as f64;
             let split_seg = can_split && should_end_this_segment;
-            let split_partial = stream_type == AVMediaType::VIDEO
-                && self.low_latency
-                && (cur_part_duration >= self.partial_target_duration as f64 || split_seg);
+            // Partials are produced for the reference stream of every LL variant:
+            // video keyframe-bounded parts for video variants, and per-packet
+            // bounded parts for audio-only (CMAF rendition) variants. Audio-only
+            // variants MUST also emit parts, otherwise their playlist advertises
+            // PART-INF without ever publishing an EXT-X-PART and LL players stall.
+            let split_partial = self.low_latency
+                && (Self::partial_would_exceed_target(
+                    cur_part_duration,
+                    pkt_duration,
+                    self.partial_target_duration as f64,
+                ) || split_seg);
 
             if split_partial {
-                self.split_partial_segment(pkt_pts, true)?;
+                self.split_partial_segment(pkt_dts, true)?;
                 self.next_partial_independent = can_split;
             }
             if split_seg {
@@ -475,6 +497,12 @@ impl HlsVariant {
                 _ => None,
             })
             .unwrap_or(0);
+        ensure!(
+            end_pos >= previous_end_pos,
+            "Partial segment byte range would be negative (end_pos={}, previous_end_pos={})",
+            end_pos,
+            previous_end_pos
+        );
         let partial_size = end_pos - previous_end_pos;
         let partial_info = PartialSegmentInfo {
             index: self.current_partial_index,
@@ -737,16 +765,12 @@ impl HlsVariant {
             });
         }
 
-        // append segment preload for next part segment
-        if let Some(HlsSegment::Partial(partial)) = self.segments.last() {
-            // TODO: try to estimate if there will be another partial segment
-            pl.segments.push(MediaSegmentType::PreloadHint(PreloadHint {
-                hint_type: "PART".to_string(),
-                uri: partial.filename(),
-                byte_range_start: partial.end_pos(),
-                byte_range_length: None,
-            }));
-        }
+        // NOTE: we intentionally do NOT emit EXT-X-PRELOAD-HINT. The segment
+        // handler serves plain files and cannot hold an open-ended range request
+        // until the hinted part is flushed; players acting on a hint would either
+        // get 416s or a truncated (mid-fragment) response, corrupting playback.
+        // The hint is optional per spec, so players fall back to fetching the
+        // byte ranges advertised in the playlist, which are always complete.
 
         pl.version = Some(self.playlist_version());
         pl.target_duration = if self.playlist_version() >= 6 {
@@ -895,5 +919,99 @@ impl HlsVariant {
                 other_attributes: None,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: parts were closed only once their duration reached
+    /// PART-TARGET, making every part exceed the advertised target (LL-HLS
+    /// spec violation, breaks strict players like Safari). The part must be
+    /// closed *before* the packet that would cross the boundary.
+    #[test]
+    fn partial_split_never_exceeds_part_target() {
+        let target = 0.5;
+        let frame = 1.0 / 30.0;
+
+        // simulate a stream of 30fps packets and collect closed part durations
+        let mut part_start = 0.0f64;
+        let mut closed = Vec::new();
+        let mut pts = 0.0f64;
+        for _ in 0..300 {
+            let cur_part_duration = pts - part_start;
+            if HlsVariant::partial_would_exceed_target(cur_part_duration, frame, target) {
+                closed.push(cur_part_duration);
+                part_start = pts;
+            }
+            pts += frame;
+        }
+
+        assert!(!closed.is_empty(), "should have closed parts");
+        for d in &closed {
+            assert!(
+                *d <= target + f64::EPSILON,
+                "part duration {} exceeds PART-TARGET {}",
+                d,
+                target
+            );
+        }
+    }
+
+    #[test]
+    fn partial_split_falls_back_when_duration_unknown() {
+        // unknown packet duration: close once target reached (old behavior)
+        assert!(HlsVariant::partial_would_exceed_target(0.5, 0.0, 0.5));
+        assert!(!HlsVariant::partial_would_exceed_target(0.49, 0.0, 0.5));
+    }
+
+    #[test]
+    fn partial_split_boundary_conditions() {
+        // would cross the target -> split now
+        assert!(HlsVariant::partial_would_exceed_target(0.48, 0.033, 0.5));
+        // still fits inside the target -> keep accumulating
+        assert!(!HlsVariant::partial_would_exceed_target(0.45, 0.033, 0.5));
+        // exactly reaching the target is allowed (parts may equal PART-TARGET)
+        assert!(!HlsVariant::partial_would_exceed_target(0.4, 0.1, 0.5));
+    }
+
+    /// Regression: reloading a playlist on stream resume used to keep trailing
+    /// EXT-X-PART entries. Those reference byte ranges of a file from the
+    /// previous run which the new stream overwrites, corrupting the byte-range
+    /// chain (and potentially underflowing the next partial size computation).
+    #[test]
+    fn try_load_media_seq_drops_trailing_partials() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        // dummy segment payloads (content doesn't matter, only hashing)
+        std::fs::write(dir_path.join("10.m4s"), b"seg10").unwrap();
+        std::fs::write(dir_path.join("11.m4s"), b"seg11").unwrap();
+        std::fs::write(dir_path.join("12.m4s"), b"seg12-partial").unwrap();
+
+        let playlist = "#EXTM3U\n\
+#EXT-X-VERSION:6\n\
+#EXT-X-TARGETDURATION:2\n\
+#EXT-X-MEDIA-SEQUENCE:10\n\
+#EXT-X-PART-INF:PART-TARGET=0.5\n\
+#EXTINF:2,\n10.m4s\n\
+#EXTINF:2,\n11.m4s\n\
+#EXT-X-PART:DURATION=0.5,URI=\"12.m4s\",BYTERANGE=\"100@0\",INDEPENDENT=YES\n\
+#EXT-X-PART:DURATION=0.5,URI=\"12.m4s\",BYTERANGE=\"100@100\"\n\
+#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"12.m4s\",BYTERANGE-START=200\n";
+        std::fs::write(dir_path.join(HlsVariant::PLAYLIST_NAME), playlist).unwrap();
+
+        let segments = HlsVariant::try_load_media_seq(&dir_path).unwrap();
+
+        assert_eq!(segments.len(), 2, "only full segments should be loaded");
+        let indexes: Vec<u64> = segments
+            .iter()
+            .map(|s| match s {
+                HlsSegment::Full(f) => f.index,
+                HlsSegment::Partial(_) => panic!("partial segments must be dropped on resume"),
+            })
+            .collect();
+        assert_eq!(indexes, vec![10, 11]);
     }
 }

--- a/crates/core/src/test_hls_timing.rs
+++ b/crates/core/src/test_hls_timing.rs
@@ -958,6 +958,111 @@ mod tests {
         );
     }
 
+    /// LL-HLS invariants over a real generated fMP4 stream. Regression coverage for:
+    /// - audio-only (CMAF rendition) playlists advertising PART-INF but never
+    ///   publishing any EXT-X-PART (LL players stall on blocking reload)
+    /// - part durations exceeding the advertised PART-TARGET
+    /// - non-contiguous part byte-range chains
+    /// - EXT-X-PRELOAD-HINT being emitted (the file-based segment handler cannot
+    ///   serve open-ended ranges of a still-growing file without truncation)
+    #[ignore]
+    #[test]
+    fn test_ll_hls_invariants() {
+        tracing_subscriber::fmt::try_init().ok();
+
+        let temp_dir = tempdir().unwrap();
+        let tester = HlsTimingTester::new(0.2, 1.0, 0.5);
+
+        let (_muxer, out_dir) = tester
+            .generate_test_stream(temp_dir.path(), 8.0, SegmentType::FMP4)
+            .expect("generation failed");
+
+        // find every variant/rendition media playlist under the output dir
+        let mut playlists = Vec::new();
+        for entry in fs::read_dir(&out_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() && path.join("live.m3u8").exists() {
+                playlists.push(path.join("live.m3u8"));
+            }
+        }
+        assert!(
+            playlists.len() >= 2,
+            "expected video variant + audio rendition playlists, found {}",
+            playlists.len()
+        );
+
+        for pl_path in &playlists {
+            let raw = fs::read(pl_path).unwrap();
+            let pl = match m3u8_rs::parse_playlist_res(&raw) {
+                Ok(m3u8_rs::Playlist::MediaPlaylist(m)) => m,
+                other => panic!("expected media playlist at {:?}, got {:?}", pl_path, other),
+            };
+
+            let part_target = pl
+                .part_inf
+                .as_ref()
+                .map(|p| p.part_target)
+                .unwrap_or_default();
+            assert!(
+                part_target > 0.0,
+                "{:?}: LL playlist must advertise PART-INF",
+                pl_path
+            );
+
+            let mut part_count = 0usize;
+            // (per current-file byte offset) -> verify contiguous byte-range chain
+            let mut expected_offset: Option<u64> = None;
+            for seg in &pl.segments {
+                match seg {
+                    MediaSegmentType::Partial(p) => {
+                        part_count += 1;
+                        // parts must not exceed PART-TARGET (small float tolerance)
+                        assert!(
+                            p.duration <= part_target + 0.001,
+                            "{:?}: part duration {} exceeds PART-TARGET {}",
+                            pl_path,
+                            p.duration,
+                            part_target
+                        );
+                        let br = p.byte_range.as_ref().expect("parts must be byte-ranged");
+                        let offset = br.offset.unwrap_or(0);
+                        if let Some(expected) = expected_offset
+                            && offset != 0
+                        {
+                            assert_eq!(
+                                offset, expected,
+                                "{:?}: part byte-range chain not contiguous",
+                                pl_path
+                            );
+                        }
+                        expected_offset = Some(offset + br.length);
+                    }
+                    MediaSegmentType::Full(_) => {
+                        // new segment file -> byte offsets restart
+                        expected_offset = None;
+                    }
+                    MediaSegmentType::PreloadHint(h) => {
+                        panic!("{:?}: preload hint must not be emitted: {:?}", pl_path, h);
+                    }
+                }
+            }
+
+            // Regression: every LL playlist (including the audio-only CMAF
+            // rendition) must actually publish parts, otherwise LL players
+            // block forever on _HLS_part reloads.
+            assert!(
+                part_count > 0,
+                "{:?}: playlist advertises PART-INF but has no EXT-X-PART entries",
+                pl_path
+            );
+
+            println!(
+                "✓ LL invariants: {:?} parts={}, part_target={}",
+                pl_path, part_count, part_target
+            );
+        }
+    }
+
     #[ignore]
     #[test]
     fn test_generated_hls_stream_fmp4() {


### PR DESCRIPTION
Fixes #95

Users reported playback stability issues in the video feed. Investigation found several defects in the LL-HLS implementation (introduced with #88 / CMAF audio grouping) that match the symptoms:

## Fixes

1. **Audio renditions stalled LL players** — audio-only CMAF rendition playlists advertised `EXT-X-PART-INF` + `CAN-BLOCK-RELOAD=YES` but never published a single `EXT-X-PART` (partial splits required a video packet). LL players issued blocking reloads with `_HLS_part` that hit the 6s timeout on **every request**, starving audio and stalling the whole feed. Partials are now emitted for the reference stream of every LL variant, including audio-only ones.

2. **Every part exceeded PART-TARGET** — parts were closed once their duration *reached* the target, so actual durations were always target + up-to-one-frame. Additionally, with B-frames the split ran on the non-monotonic decode-order PTS and could overshoot by several frames (0.533s vs 0.5s advertised). Parts are now closed *before* the packet that would cross the boundary, tracked on the DTS timeline. Strict players (Safari) reject playlists whose parts exceed PART-TARGET.

3. **Stale partials corrupted stream resume** — reloading a playlist on reconnect kept trailing `EXT-X-PART` entries referencing byte ranges of a file the new stream overwrites, corrupting the byte-range chain and potentially underflowing the next partial's size computation (panic in debug builds). Trailing partials are now dropped on resume.

4. **EXT-X-PRELOAD-HINT removed** — the file-based segment handler can't hold open-ended range requests for a still-growing file; players acting on the hint got 416s or truncated mid-fragment responses (decode errors that look encoding-related). The hint is optional per spec; players fall back to the advertised byte ranges, which are always complete on disk.

5. **PART-TARGET consistency** — low latency is now enabled *after* segment lengths are forced equal across variants, so every rendition derives PART-TARGET from the final segment length.

## Tests

- Unit tests for the part-split logic (never exceeds PART-TARGET across a simulated 30fps stream, boundary conditions, unknown-duration fallback)
- Unit test for playlist resume dropping trailing partials
- New end-to-end invariant test (`debug-hls` feature): generates a real H.264/AAC stream through `HlsMuxer` and asserts every LL rendition publishes parts, no part exceeds PART-TARGET, byte-range chains are contiguous, and no preload hints are emitted. This test caught the B-frame/DTS bug that static review missed.

Pre-existing failures on `main` (ignored e2e timing tests, multitrack nvidia test on macOS, repo-wide fmt drift) are unaffected.