### PR TITLE
ci: speed up docker builds (native arm64 + cargo-chef)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,11 +11,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-zap-stream-core:
-    name: Build zap-stream-core
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.image }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each arch builds natively (arm64 on GitHub's free arm runners)
+          # instead of emulating arm64 under QEMU, which made builds take ~1h45.
+          - image: zap-stream-core
+            dockerfile: ./crates/zap-stream/Dockerfile
+            arch: amd64
+            runner: ubuntu-latest
+          - image: zap-stream-core
+            dockerfile: ./crates/zap-stream/Dockerfile
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - image: n94-bridge
+            dockerfile: ./crates/n94-bridge/Dockerfile
+            arch: amd64
+            runner: ubuntu-latest
+          - image: n94-bridge
+            dockerfile: ./crates/n94-bridge/Dockerfile
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,38 +51,36 @@ jobs:
           username: voidic
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push zap-stream-core
+      - name: Build and push ${{ matrix.image }} (${{ matrix.arch }})
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./crates/zap-stream/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.arch }}
           push: true
-          tags: voidic/zap-stream-core:latest
+          tags: voidic/${{ matrix.image }}:latest-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
 
-  build-n94-bridge:
-    name: Build n94-bridge
+  merge:
+    name: Publish ${{ matrix.image }} multi-arch manifest
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: read
+    strategy:
+      matrix:
+        image: [zap-stream-core, n94-bridge]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: voidic
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push n94-bridge
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./crates/n94-bridge/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: voidic/n94-bridge:latest
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t voidic/${{ matrix.image }}:latest \
+            voidic/${{ matrix.image }}:latest-amd64 \
+            voidic/${{ matrix.image }}:latest-arm64

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -27,8 +27,8 @@ jobs:
           file: ./crates/zap-stream/Dockerfile
           platforms: linux/amd64
           push: false
-          cache-from: type=gha,scope=zap-stream-core
-          cache-to: type=gha,mode=max,scope=zap-stream-core
+          cache-from: type=gha,scope=zap-stream-core-amd64
+          cache-to: type=gha,mode=max,scope=zap-stream-core-amd64
 
   build-n94-bridge:
     name: Build n94-bridge
@@ -49,5 +49,5 @@ jobs:
           file: ./crates/n94-bridge/Dockerfile
           platforms: linux/amd64
           push: false
-          cache-from: type=gha,scope=n94-bridge
-          cache-to: type=gha,mode=max,scope=n94-bridge
+          cache-from: type=gha,scope=n94-bridge-amd64
+          cache-to: type=gha,mode=max,scope=n94-bridge-amd64

--- a/crates/n94-bridge/Dockerfile
+++ b/crates/n94-bridge/Dockerfile
@@ -1,12 +1,29 @@
-FROM rust:bookworm AS build
+FROM rust:trixie AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app/src
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS build
+# Share the target dir between `cargo chef cook` and `cargo install` so the
+# cooked dependency artifacts are reused for the final build.
+ENV CARGO_TARGET_DIR=/app/src/target
+COPY --from=planner /app/src/recipe.json recipe.json
+# Build dependencies only. This layer is keyed on recipe.json (Cargo.toml +
+# Cargo.lock), so CI layer caching reuses it for any commit that only touches
+# source code. Cook only n94-bridge's deps: other workspace members need
+# ffmpeg headers which this image doesn't have.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef cook --release -p n94-bridge --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/src/target,sharing=shared \
     cargo install --path ./crates/n94-bridge --root /app/build
 
-FROM rust:bookworm
+FROM rust:trixie
 WORKDIR /app
 COPY --from=build /app/build .
 ENTRYPOINT ["/app/bin/n94-bridge"]

--- a/crates/zap-stream/Dockerfile
+++ b/crates/zap-stream/Dockerfile
@@ -1,13 +1,30 @@
-FROM voidic/rust-ffmpeg:latest AS build
+FROM voidic/rust-ffmpeg:latest AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app/src
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS build
 ENV LD_LIBRARY_PATH=$FFMPEG_DIR/lib
+# Share the target dir between `cargo chef cook` and `cargo install` so the
+# cooked dependency artifacts are reused for the final build.
+ENV CARGO_TARGET_DIR=/app/src/target
 ARG CARGO_FEATURES=""
 RUN apt update && \
     apt install -y protobuf-compiler
+COPY --from=planner /app/src/recipe.json recipe.json
+# Build dependencies only. This layer is keyed on recipe.json (Cargo.toml +
+# Cargo.lock), so CI layer caching reuses it for any commit that only touches
+# source code. NOTE: no cache mount over $CARGO_TARGET_DIR here — that would
+# shadow the cooked artifacts and defeat layer caching on CI.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef cook --release -p zap-stream --recipe-path recipe.json ${CARGO_FEATURES}
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/src/target,sharing=shared \
     cargo install --path ./crates/zap-stream --root /app/build ${CARGO_FEATURES}
 
 FROM debian:trixie-slim


### PR DESCRIPTION
Main-branch docker builds take ~1h45 ([example](https://github.com/v0l/zap-stream-core/actions)). Two causes, two fixes:

## 1. Native arm64 builds instead of QEMU
`linux/amd64,linux/arm64` was built on a single `ubuntu-latest` runner, so the arm64 half ran under QEMU emulation (~10x slower for Rust + LTO). The build workflow is now a per-arch matrix — arm64 runs natively on GitHub's free `ubuntu-24.04-arm` runners — pushing `:latest-amd64` / `:latest-arm64`, followed by a merge job that publishes the `:latest` multi-arch manifest via `docker buildx imagetools create`.

## 2. cargo-chef for real CI dependency caching
The Dockerfiles used BuildKit cache mounts over the cargo target dir, but **cache mounts are not exported to the GHA layer cache** — every CI build recompiled all dependencies. Both Dockerfiles now use [cargo-chef](https://github.com/LukeMathWalker/cargo-chef):
- deps are cooked in a layer keyed on `recipe.json` (Cargo.toml + Cargo.lock), so source-only commits rebuild just the workspace crates
- `CARGO_TARGET_DIR` is pinned so `cargo install` reuses the cooked artifacts
- each image cooks only its own package (`-p`) — n94-bridge has no ffmpeg headers
- the target-dir cache mount is removed (it would shadow the cooked layer)

The main workflow now also exports/imports the GHA layer cache (previously only PR builds had cache), and PR/main scopes are aligned per image+arch so PRs warm-start from main's cache.

Also: n94-bridge images bumped bookworm → trixie (matches zap-stream's trixie runtime; `rust:trixie` publishes amd64+arm64).

Validated: `cargo chef prepare` produces a recipe for this workspace (edition 2024 + git deps), workflow YAML parses, base images (`voidic/rust-ffmpeg`, `rust:trixie`) publish arm64 manifests.

**Expected result:** cold builds ~15-25 min (native, parallel per arch); warm builds (deps cached) considerably less.